### PR TITLE
Visualizer changes based on comments made on PR 246

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -44,6 +44,9 @@ class Visualizer extends NCubeGroovyController
 
 	private VisualizerHelper helper = new VisualizerHelper()
 
+	public static final String STATUS_MISSING_SCOPE = 'missingScope'
+	public static final String STATUS_SUCCESS = 'success'
+
 	private List messages = []
 	private Set visited = []
 
@@ -86,13 +89,13 @@ class Visualizer extends NCubeGroovyController
 		//TODO: Also handle the user adding the required scope key but with a value that results in a no hit.
 		if (hasMissingScope(visInfo))
 		{
-			return [status: 'missingScope', visInfo: visInfo, message: messages.toString()]
+			return [status: STATUS_MISSING_SCOPE, visInfo: visInfo, message: messages.toString()]
 		}
 
 		getRpmVisualization(visInfo)
 
 		String message = messages.size() > 0 ? messages.toString() : null
-		return [status: 'success', visInfo: visInfo, message: message]
+		return [status: STATUS_SUCCESS, visInfo: visInfo, message: message]
 	}
 
 	private void getRpmVisualization(VisualizerInfo visInfo)
@@ -205,7 +208,7 @@ class Visualizer extends NCubeGroovyController
 			relInfo.targetTraitMaps = targetTraitMaps
 		}
 
-		String busType = 'UNSPECIFIED'
+		String busType = UNSPECIFIED
 
 		targetTraitMaps.each { k, v ->
 			String targetFieldName = k as String
@@ -284,7 +287,6 @@ class Visualizer extends NCubeGroovyController
 			nextRelInfo.sourceFieldName = targetFieldName
 			nextRelInfo.sourceFieldRpmType = rpmType
 
-
 			long nextTargetTargetLevel = relInfo.targetLevel + 1
 			nextRelInfo.targetLevel = nextTargetTargetLevel
 
@@ -331,7 +333,6 @@ class Visualizer extends NCubeGroovyController
 		NCube targetCube = relInfo.targetCube
 		String sourceFieldName = relInfo.sourceFieldName
 		Map sourceTraitMaps = relInfo.sourceTraitMaps
-
 
 		Map edgeMap = [:]
 		String sourceCubeEffectiveName = getEffectiveName(sourceCube, sourceTraitMaps)
@@ -523,7 +524,7 @@ class Visualizer extends NCubeGroovyController
 
 	private static String getNextTargetCubeName(VisualizerRelInfo relInfo, String targetFieldName)
 	{
-		if (relInfo.sourceCube.getAxis('TRAIT').contains(R_SCOPED_NAME))
+		if (relInfo.sourceCube.getAxis(AXIS_TRAIT).contains(R_SCOPED_NAME))
 		{
 			if (relInfo.sourceTraitMaps[CLASS_TRAITS][R_SCOPED_NAME] == null)
 			{
@@ -560,7 +561,7 @@ class Visualizer extends NCubeGroovyController
 		{
 			newScope[SOURCE_FIELD_NAME] = targetFieldName
 		}
-		else if (targetCube.getAxis('TRAIT').contains(R_SCOPED_NAME))
+		else if (targetCube.getAxis(AXIS_TRAIT).contains(R_SCOPED_NAME))
 		{
 			String newScopeKey = sourceFieldRpmType.toLowerCase()
 			String oldValue = scope[newScopeKey]

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -50,7 +50,7 @@ class Visualizer extends NCubeGroovyController
 	private List messages = []
 	private Set visited = []
 
-	Deque<VisualizerRelInfo> stack = new ArrayDeque<VisualizerRelInfo>()
+	Deque<VisualizerRelInfo> stack = new ArrayDeque<>()
 
 	/**
 	 * Provides the information used to visualize rpm cubes associated with a given rpm cube.
@@ -129,12 +129,12 @@ class Visualizer extends NCubeGroovyController
 
 	private void processClassCube(VisualizerInfo visInfo, VisualizerRelInfo relInfo)
 	{
-		NCube targetCube = relInfo.targetCube
+		String targetCubeName = relInfo.targetCube.name
 		Map targetScope = relInfo.targetScope
 
 		Map targetTraitMaps = relInfo.targetTraitMaps
 		if (!targetTraitMaps) {
-			targetTraitMaps = helper.getTraitMaps(targetCube.name, targetScope)
+			targetTraitMaps = helper.getTraitMaps(targetCubeName, targetScope)
 			relInfo.targetTraitMaps = targetTraitMaps
 		}
 
@@ -142,14 +142,9 @@ class Visualizer extends NCubeGroovyController
 
 		addToEdges(visInfo, relInfo)
 
-		String visitedKey = targetCube.name + targetScope.toString()
-		if (visited.contains(visitedKey))
+		if (!visited.add(targetCubeName + targetScope.toString()))
 		{
 			return
-		}
-		else
-		{
-			visited << visitedKey
 		}
 
 		visInfo.availableGroupsAllLevels << busType
@@ -245,14 +240,9 @@ class Visualizer extends NCubeGroovyController
 
 		addToEdges(visInfo, relInfo)
 
-		String visitedKey = targetCubeName + targetScope.toString()
-		if (visited.contains(visitedKey))
+		if (!visited.add(targetCubeName + targetScope.toString()))
 		{
 			return
-		}
-		else
-		{
-			visited << visitedKey
 		}
 
 		visInfo.availableGroupsAllLevels << busType

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -1,0 +1,21 @@
+package com.cedarsoftware.util
+
+import com.cedarsoftware.ncube.NCube
+import groovy.transform.CompileStatic
+
+/**
+ * Holds information related to the visualization of cubes and their relationships.
+ */
+
+@CompileStatic
+class VisualizerInfo
+{
+    long maxLevel
+	long nodeCount
+	long selectedLevel
+
+	Map allGroups
+	Set selectedGroups
+	Set availableGroupsAllLevels
+	String groupSuffix
+}

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -10,6 +10,11 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class VisualizerInfo
 {
+	String startCubeName
+	Map scope
+	List nodes
+	List edges
+
     long maxLevel
 	long nodeCount
 	long selectedLevel

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -1,0 +1,26 @@
+package com.cedarsoftware.util
+
+import com.cedarsoftware.ncube.NCube
+import groovy.transform.CompileStatic
+import ncube.grv.method.NCubeGroovyController
+
+/**
+ * Holds information about a source cube and target cube for purposes of creating a visualization of the cubes and their relationship.
+ */
+
+@CompileStatic
+class VisualizerRelInfo
+{
+	long id
+
+    NCube targetCube
+	Map targetScope
+	Map targetTraitMaps
+	long targetLevel
+
+	NCube sourceCube
+	Map sourceScope
+	Map sourceTraitMaps
+	String sourceFieldName
+	String sourceFieldRpmType
+}

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -193,7 +193,7 @@ var Visualizer = (function ($) {
                     _nce.showNote(json.message);
                 }
                 _loadedCubeName = _nce.getSelectedCubeName();
-                loadNetworkData(json.map);
+                loadNetworkData(json.visInfo);
                 trimNetworkData(null);
                 draw();
                 loadSelectedLevelListView();
@@ -208,7 +208,7 @@ var Visualizer = (function ($) {
             else if (json.status === 'missingScope') {
                 _nce.showNote(json.message);
                 _loadedCubeName = _nce.getSelectedCubeName();
-                _scope = json.scope;
+                _scope = json.visInfo.scope;
                 loadScopeView();
                 _visualizerContent.show();
                 _visualizerInfo.hide();
@@ -469,18 +469,18 @@ var Visualizer = (function ($) {
         _networkData = {nodes:nodes, edges:edges};
     }
 
-    function loadNetworkData(jsonMap) {
-        _allGroups = jsonMap.visInfo.allGroups;
-        _availableGroupsAllLevels = jsonMap.visInfo.availableGroupsAllLevels['@items'];
-        _selectedGroups = jsonMap.visInfo.selectedGroups['@items'];
-        _selectedLevel = jsonMap.visInfo.selectedLevel;
-        _groupSuffix = jsonMap.visInfo.groupSuffix;
-        _scope = jsonMap.scope;
-        _startCube = jsonMap.startCube.substring(jsonMap.startCube.lastIndexOf('.') + 1);
-        _nodeCount = jsonMap.visInfo.nodeCount;
-        _maxLevel = jsonMap.visInfo.maxLevel;
-        _nodesAllLevels = jsonMap.nodes['@items'];
-        _edgesAllLevels = jsonMap.edges['@items'];
+    function loadNetworkData(visInfo) {
+        _allGroups = visInfo.allGroups;
+        _availableGroupsAllLevels = visInfo.availableGroupsAllLevels['@items'];
+        _selectedGroups = visInfo.selectedGroups['@items'];
+        _selectedLevel = visInfo.selectedLevel;
+        _groupSuffix = visInfo.groupSuffix;
+        _scope = visInfo.scope;
+        _startCube = visInfo.startCubeName.substring(visInfo.startCubeName.lastIndexOf('.') + 1);
+        _nodeCount = visInfo.nodeCount;
+        _maxLevel = visInfo.maxLevel;
+        _nodesAllLevels = visInfo.nodes['@items'];
+        _edgesAllLevels = visInfo.edges['@items'];
     }
 
     var handleCubeSelected = function() {

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -470,17 +470,17 @@ var Visualizer = (function ($) {
     }
 
     function loadNetworkData(jsonMap) {
-        _allGroups = jsonMap.groups.allGroups;
-        _availableGroupsAllLevels = jsonMap.groups.availableGroupsAllLevels;
-        _selectedGroups = jsonMap.groups.selectedGroups;
-        _selectedLevel = jsonMap.levels.selectedLevel;
-        _groupSuffix = jsonMap.groups.groupSuffix;
+        _allGroups = jsonMap.visInfo.allGroups;
+        _availableGroupsAllLevels = jsonMap.visInfo.availableGroupsAllLevels['@items'];
+        _selectedGroups = jsonMap.visInfo.selectedGroups['@items'];
+        _selectedLevel = jsonMap.visInfo.selectedLevel;
+        _groupSuffix = jsonMap.visInfo.groupSuffix;
         _scope = jsonMap.scope;
         _startCube = jsonMap.startCube.substring(jsonMap.startCube.lastIndexOf('.') + 1);
-        _nodeCount = jsonMap.levels.nodeCount;
-        _maxLevel = jsonMap.levels.maxLevel;
-        _nodesAllLevels = jsonMap.nodes;
-        _edgesAllLevels = jsonMap.edges;
+        _nodeCount = jsonMap.visInfo.nodeCount;
+        _maxLevel = jsonMap.visInfo.maxLevel;
+        _nodesAllLevels = jsonMap.nodes['@items'];
+        _edgesAllLevels = jsonMap.edges['@items'];
     }
 
     var handleCubeSelected = function() {


### PR DESCRIPTION
1.	Create new VisualizerRelnfo class that holds info about a source and target cube and their relationship. Use new class in Visualizer instead of a map. 
2.	Pass in VisualizerRelnfo to the  processCube method and its sub-methods, rather than relying on as member variable.
3.	Create new Visualizerlnfo class that holds info about scope, groups, levels, nodes and edges. Use new class in Visualizer instead of maps. 
4.	Remove usage of .toArray.
5.	Create variable for value.lastIndexOf in getDotSuffix method.
