### PR TITLE
Added getSearchCount that returns the number of results found by search

### DIFF
--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -263,6 +263,11 @@ class NCubeController extends BaseController
         }
     }
 
+    int getSearchCount(ApplicationID appId, String cubeNamePattern = null, String content = null, boolean active = true)
+    {
+        return search(appId, cubeNamePattern, content, active).length
+    }
+
     void restoreCubes(ApplicationID appId, Object[] cubeNames)
     {
         try


### PR DESCRIPTION
DevOps requested a way to see the active n-cube count for a given ApplicationID, which will allow them to automate the verification of an n-cube release.

I decided to piggyback off of search and default cubeNamePattern, content and active to make the call easier for them, but also allow for a more robust search count if necessary.