### PR TITLE
Change Visualizer to retrieve only a minimal set of traits

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -1,6 +1,7 @@
 package com.cedarsoftware.util
 
 import com.cedarsoftware.ncube.NCube
+import com.cedarsoftware.util.io.JsonWriter
 import groovy.transform.CompileStatic
 import ncube.grv.method.NCubeGroovyController
 
@@ -96,6 +97,14 @@ class Visualizer extends NCubeGroovyController
 		getRpmVisualization(visInfo)
 
 		String message = messages.size() > 0 ? messages.toString() : null
+
+		//TODO: Remove before creating pull request. Used temporarily for regression testing.
+		String jsonFolder = 'C:/json'
+		new File(jsonFolder, 'visInfoNew.json').withWriter('utf-8') {
+			writer ->
+				writer.writeLine(JsonWriter.objectToJson(visInfo))
+		}
+
 		return [status: STATUS_SUCCESS, visInfo: visInfo, message: message]
 	}
 
@@ -185,7 +194,7 @@ class Visualizer extends NCubeGroovyController
 
 	private void processEnumCube(VisualizerInfo visInfo, VisualizerRelInfo relInfo)
 	{
-	 	Map targetScope = relInfo.targetScope
+		Map targetScope = relInfo.targetScope
 		String targetCubeName = relInfo.targetCube.name
 		String sourceFieldRpmType =  relInfo.sourceFieldRpmType
 
@@ -421,7 +430,6 @@ class Visualizer extends NCubeGroovyController
 		sb.append('<strong>level = </strong>' + nodeMap.level.toString() + '<br><br>')
 
 		sb.append(getTitleFields(traitMaps))
-		sb.append(getTitleClassTraits(traitMaps))
 
 		return sb.toString();
 	}
@@ -446,19 +454,6 @@ class Visualizer extends NCubeGroovyController
 		}
 
 		return fieldDetails.toString();
-	}
-
-	private static String getTitleClassTraits(Map traitMaps)
-	{
-		StringBuilder traits = new StringBuilder()
-		traits.append('<br><br><strong>class traits = </strong><br>')
-		Map classTraits = traitMaps[CLASS_TRAITS] as Map
-		classTraits.each { k,v ->
-			String key = k as String
-			String value = v as String
-			traits.append(SPACE + key + ' = ' + value + '<br>')
-		}
-		return traits.toString()
 	}
 
 	private static String getEffectiveName(NCube cube, Map traitMaps)

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -1,7 +1,6 @@
 package com.cedarsoftware.util
 
 import com.cedarsoftware.ncube.NCube
-import com.cedarsoftware.util.io.JsonWriter
 import com.google.common.base.Splitter
 import groovy.transform.CompileStatic
 import ncube.grv.method.NCubeGroovyController
@@ -97,14 +96,6 @@ class Visualizer extends NCubeGroovyController
 		getRpmVisualization(visInfo)
 
 		String message = messages.size() > 0 ? messages.toString() : null
-
-		//TODO: Remove before creating pull request. Used temporarily for regression testing.
-		String jsonFolder = 'C:/json'
-		new File(jsonFolder, 'visInfoNewWorkersCompensationProduct.json').withWriter('utf-8') {
-			writer ->
-				writer.writeLine(JsonWriter.objectToJson(visInfo))
-		}
-
 		return [status: STATUS_SUCCESS, visInfo: visInfo, message: message]
 	}
 

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -34,7 +34,7 @@ class Visualizer extends NCubeGroovyController
 
 	public static final String _ENUM = '_ENUM'
 	public static final String UNSPECIFIED = 'UNSPECIFIED'
-	public static final Map ALL_GROUPS_MAP = [PRODUCT:'Product', FORM:'Form', FORMDATA:'Form data', RISK:'Risk', COVERAGE:'Coverage', CONTAINER:'Container', DEDUCTIBLE:'Deductible', LIMIT:'Limit', RATE:'Rate', RATEFACTOR:'Rate Factor', PREMIUM:'Premium', PARTY:'Party', PLACE:'Place', ROLE:'Role', ROLEPLAYER:'Role Player', UNSPECIFIED:'Unspecified']
+	public static final Map ALL_GROUPS_MAP = [PRODUCT:'Product', FORM:'Form', RISK:'Risk', COVERAGE:'Coverage', CONTAINER:'Container', DEDUCTIBLE:'Deductible', LIMIT:'Limit', RATE:'Rate', RATEFACTOR:'Rate Factor', PREMIUM:'Premium', PARTY:'Party', PLACE:'Place', ROLE:'Role', ROLEPLAYER:'Role Player', UNSPECIFIED:'Unspecified']
 	public static final String[] GROUPS_TO_SHOW_IN_TITLE = ['COVERAGE', 'DEDUCTIBLE', 'LIMIT', 'PREMIUM', 'PRODUCT', 'RATE', 'RATEFACTOR', 'RISK', 'ROLEPLAYER', 'ROLE']
 
 	public static final Map DEFAULT_SCOPE = [context: 'Edit', action: 'Edit']
@@ -100,7 +100,7 @@ class Visualizer extends NCubeGroovyController
 
 		//TODO: Remove before creating pull request. Used temporarily for regression testing.
 		String jsonFolder = 'C:/json'
-		new File(jsonFolder, 'visInfoNew.json').withWriter('utf-8') {
+		new File(jsonFolder, 'visInfoNewWorkersCompensationProduct.json').withWriter('utf-8') {
 			writer ->
 				writer.writeLine(JsonWriter.objectToJson(visInfo))
 		}
@@ -227,17 +227,17 @@ class Visualizer extends NCubeGroovyController
 
 					if (nextTargetCubeName)
 					{
-						NCube nextTargetCube = getCube(RPM_CLASS_DOT + nextTargetCubeName)
+						NCube nextTargetCube = getCube(nextTargetCubeName)
 						if (nextTargetCube)
 						{
-							VisualizerRelInfo nextTargetRelInfo = addToStack(visInfo, relInfo, nextTargetCube, relInfo.sourceFieldRpmType, targetFieldName)
+							addToStack(visInfo, relInfo, nextTargetCube, relInfo.sourceFieldRpmType, targetFieldName)
 
 							if (group == UNSPECIFIED) {
 								group = getGroup(nextTargetCubeName)
 							}
 						}
 						else{
-							messages << 'No cube exists with name of ' + RPM_ENUM_DOT + nextTargetCubeName + '. It is therefore not included in the visualization.'
+							messages << 'No cube exists with name of ' + nextTargetCubeName + '. It is therefore not included in the visualization.'
 						}
 					}
 				}
@@ -319,7 +319,7 @@ class Visualizer extends NCubeGroovyController
 	private static String getGroup(String cubeName)
 	{
 		Iterable<String> splits = Splitter.on('.').split(cubeName)
-		String group = splits[splits.size()-1].toUpperCase()
+		String group = splits[2].toUpperCase()
 		Set groups = ALL_GROUPS_MAP.keySet()
 		return groups.contains(group) ? group : UNSPECIFIED
 	}
@@ -520,7 +520,7 @@ class Visualizer extends NCubeGroovyController
 			}
 			else
 			{
-				return relInfo.sourceFieldRpmType
+				return RPM_CLASS_DOT + relInfo.sourceFieldRpmType
 			}
 		}
 

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerHelper.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerHelper.groovy
@@ -32,7 +32,7 @@ public class VisualizerHelper extends NCubeGroovyController {
 	public static final String RPM_ENUM_DOT = 'rpm.enum.'
 	public static final String R_EXTENDS = 'r:extends'
 	public static final String CLASS_TRAITS = 'CLASS_TRAITS'
-	public static final String CELL_INFO_SUFFIX = '_CELL_INFO'
+	public static final List MINIMAL_TRAITS = ['r:rpmType', 'v:enum', 'r:scopedName', 'r:extends', 'r:exists', 'v:min', 'v:max', 'pd:busType' ]
 
 	/** pattern to match valid class names: names must start with letter (a-z), but allow numbers (1-9) and underscore (_). Class names are also allowed to include package name (x.y.z)
 	 *  COPIED: Copied from Dynamis
@@ -366,15 +366,16 @@ public class VisualizerHelper extends NCubeGroovyController {
 
 		Map<String, Object> traits = new CaseInsensitiveMap<String, Object>();
 
-		for (Column column : ncube.getAxis(TRAIT_AXIS).getColumns())
+		// MODIFIED: Get only the traits needed for visualization
+		for (String traitName : MINIMAL_TRAITS)
 		{
-			coord.put(TRAIT_AXIS, column.getValueThatMatches());
+			coord.put(TRAIT_AXIS, traitName);
 			try
 			{
 				Object val = ncube.getCell(coord);
 				if (!"#NOT_DEFINED".equals(val))
 				{
-					traits.put((String) column.getValue(), val);
+					traits.put((String) traitName, val);
 				}
 			}
 			catch(CoordinateNotFoundException ignored)

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerHelper.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerHelper.groovy
@@ -32,7 +32,7 @@ public class VisualizerHelper extends NCubeGroovyController {
 	public static final String RPM_ENUM_DOT = 'rpm.enum.'
 	public static final String R_EXTENDS = 'r:extends'
 	public static final String CLASS_TRAITS = 'CLASS_TRAITS'
-	public static final List MINIMAL_TRAITS = ['r:rpmType', 'v:enum', 'r:scopedName', 'r:extends', 'r:exists', 'v:min', 'v:max', 'pd:busType' ]
+	public static final List MINIMAL_TRAITS = ['r:rpmType', 'r:scopedName', 'r:extends', 'r:exists', 'v:enum', 'v:min', 'v:max']
 
 	/** pattern to match valid class names: names must start with letter (a-z), but allow numbers (1-9) and underscore (_). Class names are also allowed to include package name (x.y.z)
 	 *  COPIED: Copied from Dynamis


### PR DESCRIPTION
Changes:

1.	Changed Visualizer to retrieve only a minimal set of traits for each class.
2.	Removed class traits from title in Visualizer.
3.	Eliminated dependency on pd:busType trait in Visualizer (the Visualizer now only relies on traits recognized by Dynamis).

Tested by comparing json for the VisInfo object returned by Visualizer before and after changes. 

The server side performance for loading the Visualizer for the large WorkersCompensationProduct has improved by 33% as a result. 
