### PR TITLE
Visualizer: Allow non-EPM class as starting point for visualization

### DIFF
--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -256,10 +256,10 @@ class NCubeController extends BaseController
     // TODO: This needs to be externalized (loaded via Grapes)
     Map getVisualizerJson(ApplicationID appId, Map options)
     {
-        String cubeName = options.startCubeName
+        String cubeName = options.startCubeName as String
         if (!cubeName.startsWith(VisualizerConstants.RPM_CLASS))
         {
-            throw new IllegalArgumentException('n-cube name must begin with rpm.class, n-cube: ' + cubeName + ', app: ' + appId)
+            throw new IllegalArgumentException("The cube used as the starting point for a visualization must begin with 'rpm.class'. Cube ${cubeName} may not be used as the starting point.")
         }
         appId = addTenant(appId)
 

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -51,7 +51,7 @@ public final class VisualizerConstants
 	public static final Set<String> DEFAULT_OPTIONAL_SCOPE_KEYS = ['action', 'businessDivisionCode', 'context', 'date', 'edition', '_effectiveVersion', 'env', 'formId', 'LocationState', 'screen', 'state', 'transaction', 'transactionsubtype', 'username', 'view'] as Set
 	public static final Set<String> DEFAULT_AVAILABLE_SCOPE_KEYS = DERIVED_SCOPE_KEYS + DERIVED_SOURCE_SCOPE_KEYS + DEFAULT_OPTIONAL_SCOPE_KEYS + [POLICY_CONTROL_DATE, QUOTE_DATE, EFFECTIVE_VERSION]
 	public static final String DEFAULT_SCOPE_VALUE = '????'
-	public static final long DEFAULT_LEVEL = 2
+	public static final long DEFAULT_LEVEL = 3
 
 	public static final String ENT_APP = 'ENT.APP'
 	public static final String BUSINESS_DIVISION_CUBE_NAME = 'ent.manual.BusinessDivision'

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -5,28 +5,7 @@ import com.cedarsoftware.ncube.RuleInfo
 import com.google.common.base.Splitter
 import groovy.transform.CompileStatic
 
-import static com.cedarsoftware.util.VisualizerConstants.ALL_GROUPS_KEYS
-import static com.cedarsoftware.util.VisualizerConstants.ALL_GROUPS_MAP
-import static com.cedarsoftware.util.VisualizerConstants.AXIS_FIELD
-import static com.cedarsoftware.util.VisualizerConstants.AXIS_NAME
-import static com.cedarsoftware.util.VisualizerConstants.AXIS_TRAIT
-import static com.cedarsoftware.util.VisualizerConstants.BREAK
-import static com.cedarsoftware.util.VisualizerConstants.CLASS_TRAITS
-import static com.cedarsoftware.util.VisualizerConstants.DOUBLE_BREAK
-import static com.cedarsoftware.util.VisualizerConstants.EFFECTIVE_VERSION_SCOPE_KEY
-import static com.cedarsoftware.util.VisualizerConstants.GROUPS_TO_SHOW_IN_TITLE
-import static com.cedarsoftware.util.VisualizerConstants.NODE_LABEL_LINE_LENGTH_MULTIPLIER
-import static com.cedarsoftware.util.VisualizerConstants.NODE_LABEL_MAX_LINE_LENGTH
-import static com.cedarsoftware.util.VisualizerConstants.RPM_CLASS
-import static com.cedarsoftware.util.VisualizerConstants.RPM_CLASS_DOT
-import static com.cedarsoftware.util.VisualizerConstants.RPM_ENUM
-import static com.cedarsoftware.util.VisualizerConstants.RPM_ENUM_DOT
-import static com.cedarsoftware.util.VisualizerConstants.R_EXISTS
-import static com.cedarsoftware.util.VisualizerConstants.R_SCOPED_NAME
-import static com.cedarsoftware.util.VisualizerConstants.SPACE
-import static com.cedarsoftware.util.VisualizerConstants.SYSTEM_SCOPE_KEY_PREFIX
-import static com.cedarsoftware.util.VisualizerConstants.UNSPECIFIED
-import static com.cedarsoftware.util.VisualizerConstants._ENUM
+import static com.cedarsoftware.util.VisualizerConstants.*
 
 /**
  * Holds information about a source cube and target cube for purposes of creating a visualization of the cubes and their relationship.
@@ -228,7 +207,7 @@ class VisualizerRelInfo
 				return RPM_CLASS_DOT + sourceFieldRpmType
 			}
 		}
-		return targetFieldName
+		return RPM_CLASS_DOT + targetFieldName
 	}
 
     String getSourceMessage()


### PR DESCRIPTION
1. Fixed bug introduced with recent round of improvements that caused errors when using a non-EPM class as the starting point for a visualization.
2. Changed error message when using anything but an rpm.class as the starting point for a visualization.
3. Increase the default levels shown in the visualizer from 2 to 3.