### PR TITLE
Visualizer: Add ability to load traits and other assorted improvements

### DIFF
--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -254,7 +254,7 @@ class NCubeController extends BaseController
     }
 
     // TODO: This needs to be externalized (loaded via Grapes)
-    Map getVisualizerJson(ApplicationID appId, Map options)
+    Map<String, Object> getVisualizerJson(ApplicationID appId, Map options)
     {
         String cubeName = options.startCubeName as String
         if (!cubeName.startsWith(VisualizerConstants.RPM_CLASS))
@@ -262,12 +262,16 @@ class NCubeController extends BaseController
             throw new IllegalArgumentException("Starting cube for visualization must begin with 'rpm.class', n-cube: ${cubeName} does not.")
         }
         appId = addTenant(appId)
-
         Visualizer vis = new Visualizer()
-        vis.input = [options:options]
-        vis.output = [:]
-        vis.ncube = nCubeService.getCube(appId, cubeName)
-        return vis.buildGraph()
+        return vis.buildGraph(appId, options)
+    }
+
+    // TODO: This needs to be externalized (loaded via Grapes)
+    Map getVisualizerTraits(ApplicationID appId, Map options)
+    {
+        appId = addTenant(appId)
+        Visualizer vis = new Visualizer()
+        return vis.getTraits(appId, options)
     }
 
     Boolean updateCubeMetaProperties(ApplicationID appId, String cubeName, Map<String, Object> newMetaProperties)

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -1,16 +1,11 @@
 package com.cedarsoftware.util
 
 import com.cedarsoftware.ncube.ApplicationID
-import com.cedarsoftware.ncube.Axis
-import com.cedarsoftware.ncube.Column
 import com.cedarsoftware.ncube.NCube
 import com.cedarsoftware.ncube.NCubeManager
-import com.cedarsoftware.ncube.ReleaseStatus
 import com.cedarsoftware.ncube.exception.CoordinateNotFoundException
 import com.cedarsoftware.ncube.exception.InvalidCoordinateException
-import com.cedarsoftware.ncube.util.VersionComparator
 import groovy.transform.CompileStatic
-import ncube.grv.method.NCubeGroovyController
 
 import static com.cedarsoftware.util.VisualizerConstants.*
 
@@ -20,13 +15,12 @@ import static com.cedarsoftware.util.VisualizerConstants.*
 
 // TODO: This code needs to be moved out of NCE and pulled-in via Grapes.
 @CompileStatic
-class Visualizer extends NCubeGroovyController
+class Visualizer
 {
+	private ApplicationID appId
 	private VisualizerHelper helper = new VisualizerHelper()
 	private Set<String> messages = []
 	private Set<String> visited = []
-	private Map<String, Set<String>> requiredScopeKeys = [:]
-	private Map<String, Set<String>> optionalScopeKeys = [:]
 	private String defaultScopeEffectiveVersion
 	private String defaultScopeDate
 	private Deque<VisualizerRelInfo> stack = new ArrayDeque<>()
@@ -34,39 +28,24 @@ class Visualizer extends NCubeGroovyController
 	/**
 	 * Provides the information used to visualize rpm cubes associated with a given rpm cube.
 	 *
-	 * input:
-	 * 	          String startCubeName, name of the starting cube
-	 *            Map scope
-	 *            Set selectedGroups, indicates which groups should be included in the visualization
-	 *            String selectedLevel, indicates the depth of traversal from the start cube
-	 *
-	 * output     Map containing status, messages and visualizer information
-	 *
-	 */
-	Map buildGraph()
+	 * @param applicationID
+	 * @param options - a map containing:
+	 *            String startCubeName, name of the starting cube
+	 *            Map scope, the context for which the visualizer is loaded
+	 *            Set selectedGroups, which groups should be included in the visualization
+	 *            String selectedLevel, the depth of traversal from the start cube
+	 *            Set<String> availableScopeKeys, scope keys available in the visualization
+	 *            Map<String, Set<Object>> availableScopeValues, scope values available in the visualization, by scope key
+	 *            boolean loadTraits, whether to load and display traits
+     * @return a map containing status, messages and visualizer information
+     */
+	Map<String, Object> buildGraph(ApplicationID applicationID, Map options)
 	{
-		Map options = input.options as Map
-		String cubeName = options.startCubeName as String
-		helper.ncube = ncube
-
+		appId = applicationID
 		defaultScopeEffectiveVersion = applicationID.version.replace('.', '-')
 		defaultScopeDate = DATE_TIME_FORMAT.format(new Date())
 
-		VisualizerInfo visInfo = new VisualizerInfo()
-		visInfo.startCubeName = cubeName
-		visInfo.scope = options.scope as CaseInsensitiveMap
-		visInfo.allGroups = ALL_GROUPS_MAP
-		visInfo.availableGroupsAllLevels = [] as Set
-		visInfo.groupSuffix = _ENUM
-		visInfo.selectedGroups = options.selectedGroups as Set ?: ALL_GROUPS_KEYS
-		String selectedLevel = options.selectedLevel as String
-		visInfo.selectedLevel = selectedLevel == null ? DEFAULT_LEVEL : Converter.convert(selectedLevel, long.class) as long
-		visInfo.availableScopeKeys =  options.availableScopeKeys as Set ?: DEFAULT_AVAILABLE_SCOPE_KEYS
-		visInfo.availableScopeValues = options.availableScopeValues as Map ?: loadAvailableScopeValues()
-		visInfo.maxLevel = 1
-		visInfo.nodeCount = 1
-		visInfo.nodes = []
-		visInfo.edges = []
+		VisualizerInfo visInfo = new VisualizerInfo(appId, options)
 
 		if (hasMissingMinimumScope(visInfo))
 		{
@@ -79,11 +58,39 @@ class Visualizer extends NCubeGroovyController
 		return [status: STATUS_SUCCESS, visInfo: visInfo, message: message]
 	}
 
+	/**
+	 * Loads all traits available for a given class.
+	 *
+	 * @param applicationID
+	 * @param options (map containing:
+	 *            Map node, representing a class
+	 *            Map scope, the context for which the visualizer is loaded
+	 *            Set<String> availableScopeKeys, scope keys available in the visualization
+	 *            Map<String, Set<Object>> availableScopeValues, scope values available in the visualization, by scope key
+	 *            boolean loadTraits, whether to load and display traits
+	 * @return node
+     */
+	Map getTraits(ApplicationID applicationID, Map options)
+	{
+		appId = applicationID
+
+		VisualizerInfo visInfo = new VisualizerInfo(appId, options)
+		VisualizerRelInfo relInfo = new VisualizerRelInfo(appId, options)
+
+		getTraitMaps(visInfo, relInfo)
+		visInfo.nodes = [relInfo.createNode()]
+		visInfo.availableGroupsAllLevels << relInfo.group
+
+		String message = messages.empty ? null : messages.join(DOUBLE_BREAK)
+		return [status: STATUS_SUCCESS, visInfo: visInfo, message: message]
+	}
+
 	private void getRpmVisualization(VisualizerInfo visInfo)
 	{
 		VisualizerRelInfo relInfo = new VisualizerRelInfo()
-		relInfo.targetCube = getCube(visInfo.startCubeName)
+		relInfo.targetCube = NCubeManager.getCube(appId, visInfo.startCubeName)
 		relInfo.scope = visInfo.scope
+		relInfo.loadTraits = visInfo.loadTraits
 		relInfo.targetLevel = 1
 		relInfo.targetId = 1
 		stack.push(relInfo)
@@ -93,8 +100,8 @@ class Visualizer extends NCubeGroovyController
 			processCube(visInfo, stack.pop())
 		}
 
-		addSets(visInfo.availableScopeKeys, requiredScopeKeys.values() as Set)
-		addSets(visInfo.availableScopeKeys, optionalScopeKeys.values() as Set)
+		addSets(visInfo.availableScopeKeys, visInfo.requiredScopeKeys.values() as Set)
+		addSets(visInfo.availableScopeKeys, visInfo.optionalScopeKeys.values() as Set)
         visInfo.trimSelectedLevel()
         visInfo.trimSelectedGroups()
 	}
@@ -129,14 +136,18 @@ class Visualizer extends NCubeGroovyController
 			loadFieldsAndTraits = getTraitMaps(visInfo, relInfo)
 		}
 
-		addToEdges(visInfo, relInfo)
+		if (relInfo.sourceCube)
+		{
+			visInfo.edges << relInfo.createEdge(visInfo.edges.size())
+		}
 
 		if (!visited.add(targetCubeName + relInfo.scope.toString()))
 		{
 			return
 		}
 
-		addToNodes(visInfo, relInfo)
+		visInfo.nodes << relInfo.createNode()
+		visInfo.availableGroupsAllLevels << relInfo.group
 
 		if (loadFieldsAndTraits)
 		{
@@ -152,12 +163,12 @@ class Visualizer extends NCubeGroovyController
 						if (targetTraits.containsKey(V_ENUM))
 						{
 							nextTargetCubeName = RPM_ENUM_DOT + targetTraits[V_ENUM]
-							nextTargetCube = getCube(nextTargetCubeName)
+							nextTargetCube = NCubeManager.getCube(appId, nextTargetCubeName)
 						}
 						else if (targetFieldRpmType)
 						{
 							nextTargetCubeName = RPM_CLASS_DOT + targetFieldRpmType
-							nextTargetCube = getCube(nextTargetCubeName)
+							nextTargetCube = NCubeManager.getCube(appId, nextTargetCubeName)
 						}
 
 						if (nextTargetCube)
@@ -203,7 +214,7 @@ class Visualizer extends NCubeGroovyController
 
 						if (nextTargetCubeName)
 						{
-							NCube nextTargetCube = getCube(nextTargetCubeName)
+							NCube nextTargetCube = NCubeManager.getCube(appId, nextTargetCubeName)
 							if (nextTargetCube)
 							{
 								addToStack(visInfo, relInfo, nextTargetCube, relInfo.sourceFieldRpmType, targetFieldName)
@@ -227,18 +238,18 @@ class Visualizer extends NCubeGroovyController
 			}
 		}
 
-		addToEdges(visInfo, relInfo)
+		visInfo.edges << relInfo.createEdge(visInfo.edges.size())
 
 		if (!visited.add(targetCubeName + relInfo.scope.toString()))
 		{
 			return
 		}
 
+		visInfo.nodes << relInfo.createNode()
 		visInfo.availableGroupsAllLevels << relInfo.group
-		addToNodes(visInfo, relInfo)
 	}
 
-	private VisualizerRelInfo addToStack(VisualizerInfo visInfo, VisualizerRelInfo relInfo, NCube nextTargetCube, String rpmType, String targetFieldName)
+	private void addToStack(VisualizerInfo visInfo, VisualizerRelInfo relInfo, NCube nextTargetCube, String rpmType, String targetFieldName)
 	{
 		try
 		{
@@ -253,6 +264,7 @@ class Visualizer extends NCubeGroovyController
 			nextRelInfo.sourceFieldRpmType = rpmType
 			nextRelInfo.sourceTraitMaps = relInfo.targetTraitMaps
 			nextRelInfo.sourceId = relInfo.targetId
+			nextRelInfo.loadTraits = visInfo.loadTraits
 
 			long nextTargetTargetLevel = relInfo.targetLevel + 1
 			nextRelInfo.targetLevel = nextTargetTargetLevel
@@ -263,7 +275,6 @@ class Visualizer extends NCubeGroovyController
 			nextRelInfo.targetId = visInfo.nodeCount
 
 			stack.push(nextRelInfo)
-			return nextRelInfo
 		}
 		catch (Exception e)
 		{
@@ -283,7 +294,7 @@ class Visualizer extends NCubeGroovyController
 				targetCube.getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
 		{
 			String type = relInfo.sourceFieldRpmType
-			NCube classTraitsCube = getCube(RPM_SCOPE_CLASS_DOT + type + DOT_CLASS_TRAITS)
+			NCube classTraitsCube = NCubeManager.getCube(appId, RPM_SCOPE_CLASS_DOT + type + DOT_CLASS_TRAITS)
 			String sourceFieldName = relInfo.sourceFieldName
 			if (!classTraitsCube.getAxis(type).findColumn(sourceFieldName))
 			{
@@ -297,63 +308,6 @@ class Visualizer extends NCubeGroovyController
 		return true
 	}
 
-	private static void addToEdges(VisualizerInfo visInfo, VisualizerRelInfo relInfo)
-	{
-		NCube sourceCube = relInfo.sourceCube
-		if (!sourceCube)
-		{
-			return
-		}
-
-		String sourceFieldName = relInfo.sourceFieldName
-		Map<String, Map<String, Object>> sourceTraitMaps = relInfo.sourceTraitMaps
-
-		Map<String, String> edgeMap = [:]
-		String sourceCubeEffectiveName = relInfo.sourceEffectiveName
-		String targetCubeEffectiveName = relInfo.targetEffectiveName
-		edgeMap.id = String.valueOf(visInfo.edges.size() + 1)
-		edgeMap.from = String.valueOf(relInfo.sourceId)
-		edgeMap.to = String.valueOf(relInfo.targetId)
-		edgeMap.fromName = sourceCubeEffectiveName
-		edgeMap.toName = targetCubeEffectiveName
-		edgeMap.fromFieldName = sourceFieldName
-		edgeMap.level = String.valueOf(relInfo.targetLevel)
-		edgeMap.label = ''
-		Map<String, Map<String, Object>> sourceFieldTraitMap = sourceTraitMaps[sourceFieldName] as Map
-		String vMin = sourceFieldTraitMap[V_MIN]
-		String vMax = sourceFieldTraitMap[V_MAX]
-
-		if (vMin != null && vMax != null)
-		{
-			edgeMap.title = "${vMin}:${vMax}"
-		}
-		else
-		{
-			edgeMap.title = ''
-		}
-		visInfo.edges << edgeMap
-	}
-
-	private static void addToNodes(VisualizerInfo visInfo, VisualizerRelInfo relInfo)
-	{
-		NCube targetCube = relInfo.targetCube
-		String targetCubeName = targetCube.name
-		String sourceFieldName = relInfo.sourceFieldName
-
-		Map<String, Object> nodeMap = [:]
-		nodeMap.id = String.valueOf(relInfo.targetId)
-		nodeMap.level = String.valueOf(relInfo.targetLevel)
-		nodeMap.name = targetCubeName
-		nodeMap.scope = relInfo.targetScope
-		nodeMap.fromFieldName = sourceFieldName == null ? null : sourceFieldName
-		nodeMap.title = targetCubeName
-		nodeMap.desc = relInfo.title
-		relInfo.group ?: relInfo.setGroupName()
-		visInfo.availableGroupsAllLevels << relInfo.group
-		nodeMap.label = relInfo.label
-		nodeMap.group = relInfo.nodeGroup
-		visInfo.nodes << nodeMap
-	}
 
 	/**
 	 * Sets the basic scope required to load a target class based on scoped source class, source field name, target class name, and current scope.
@@ -405,43 +359,43 @@ class Visualizer extends NCubeGroovyController
 
 	private boolean hasMissingMinimumScope(VisualizerInfo visInfo)
 	{
-		String type
-		String messageSuffix
-		String messageSuffixTypeScopeKey = ''
-		String messageScopeValues = ''
-		String messageSuffixScopeKey = "Its default value may be changed as desired."
 		boolean hasMissingScope = false
 		String cubeName = visInfo.startCubeName
 		Map<String, Object> scope = visInfo.scope
+		String messageSuffixScopeKey = "Its default value may be changed as desired."
 
-		if (getCube(cubeName).getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
+		if (NCubeManager.getCube(appId, cubeName).getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
 		{
-			type = getTypeFromCubeName(cubeName)
-			messageSuffixTypeScopeKey = "Please replace ${DEFAULT_SCOPE_VALUE} for ${type} with an actual scope value."
-			messageScopeValues = getAvailableScopeValuesMessage(visInfo, cubeName, type)
-			messageSuffix = 'The other default scope values may also be changed as desired.'
-		}
-		else{
-			messageSuffix = 'The default scope value(s) may be changed as desired.'
-		}
-
-		if (scope)
-		{
-			if (type)
+			String type = getTypeFromCubeName(cubeName)
+			String messageSuffixTypeScopeKey = "${DOUBLE_BREAK}Please replace ${DEFAULT_SCOPE_VALUE} for ${type} with an actual scope value.${BREAK}"
+			String messageScopeValues = getAvailableScopeValuesMessage(visInfo, cubeName, type)
+			String messageSuffix = 'The other default scope values may also be changed as desired.'
+			if (scope)
 			{
 				hasMissingScope = visInfo.addMissingMinimumScope(type, DEFAULT_SCOPE_VALUE, messageSuffixTypeScopeKey + messageScopeValues, messages) ?: hasMissingScope
 				hasMissingScope = visInfo.addMissingMinimumScope(POLICY_CONTROL_DATE, defaultScopeDate, messageSuffixScopeKey, messages) ?: hasMissingScope
 				hasMissingScope = visInfo.addMissingMinimumScope(QUOTE_DATE, defaultScopeDate, messageSuffixScopeKey, messages) ?: hasMissingScope
+				hasMissingScope = visInfo.addMissingMinimumScope(EFFECTIVE_VERSION, defaultScopeEffectiveVersion, messageSuffixScopeKey, messages) ?: hasMissingScope
 			}
-			hasMissingScope = visInfo.addMissingMinimumScope(EFFECTIVE_VERSION, defaultScopeEffectiveVersion, messageSuffixScopeKey, messages) ?: hasMissingScope
+			else
+			{
+				hasMissingScope = true
+				Map<String, Object> defaultScope = getDefaultScope(type)
+				visInfo.scope = defaultScope
+				String msg = getMissingMinimumScopeMessage(defaultScope, messageScopeValues, messageSuffixTypeScopeKey, messageSuffix)
+				messages << msg
+			}
 		}
-		else
-		{
-			hasMissingScope = true
-			Map<String, Object> defaultScope = getDefaultScope(type)
-			visInfo.scope = defaultScope
-			String msg = getMissingMinimumScopeMessage(defaultScope, messageScopeValues, messageSuffixTypeScopeKey, messageSuffix )
-			messages << msg
+		else{
+			if (scope)
+			{
+				hasMissingScope = visInfo.addMissingMinimumScope(EFFECTIVE_VERSION, defaultScopeEffectiveVersion, messageSuffixScopeKey, messages) ?: hasMissingScope
+			}
+			else
+			{
+				hasMissingScope = false
+				visInfo.scope = getDefaultScope(null)
+			}
 		}
 		return hasMissingScope
 	}
@@ -450,7 +404,7 @@ class Visualizer extends NCubeGroovyController
 	{
 		try
 		{
-            relInfo.getTraitMaps(helper, requiredScopeKeys, optionalScopeKeys)
+            relInfo.getTraitMaps(helper, appId, visInfo)
             return true
 		}
 		catch (Exception e)
@@ -546,74 +500,19 @@ class Visualizer extends NCubeGroovyController
 		return (cubeName - RPM_CLASS_DOT)
 	}
 
-	private Set<Object> loadAvailableScopeValues(VisualizerInfo visInfo, String cubeName, String key)
+	private static String getAvailableScopeValuesMessage(VisualizerInfo visInfo, String cubeName, String key)
 	{
-		Set<Object> values = getColumnValues(applicationID, cubeName, key)
-		visInfo.availableScopeValues[key] = values
-		return values
-	}
-
-	private Map<String, Set<Object>> loadAvailableScopeValues()
-	{
-		Map<String, Set<Object>> valuesByKey = new CaseInsensitiveMap<>()
-
-		//Values for Risk, SourceRisk, Coverage, SourceCoverage, etc.
-		DERIVED_SCOPE_KEYS.each { String key ->
-			String cubeName = RPM_SCOPE_CLASS_DOT + key + DOT_TRAITS
-			Set<Object> values = getColumnValues(applicationID, cubeName, key)
-			valuesByKey[key] = values
-			valuesByKey[SOURCE_SCOPE_KEY_PREFIX + key] = values
-		}
-
-		//Values for effective version
-		valuesByKey[EFFECTIVE_VERSION] = getAllVersions(applicationID.tenant, applicationID.app) as Set<Object>
-
-		//Values from ENT.APP
-		String latest = NCubeManager.getLatestVersion(ApplicationID.DEFAULT_TENANT, ENT_APP, ReleaseStatus.RELEASE.name())
-		ApplicationID entAppAppId = new ApplicationID(ApplicationID.DEFAULT_TENANT, ENT_APP, latest, ReleaseStatus.RELEASE.name(), ApplicationID.HEAD)
-
-   		valuesByKey[BUSINESS_DIVISION_CODE] = getColumnValues(entAppAppId, BUSINESS_DIVISION_CUBE_NAME, BUSINESS_DIVISION_CODE)
-		Set<Object> stateValues = getColumnValues(entAppAppId, STATE_CUBE_NAME, STATE)
-		valuesByKey[STATE] = stateValues
-		valuesByKey[LOCATION_STATE] = stateValues
-
-		return valuesByKey
-	}
-
-	private static Set<Object> getColumnValues(ApplicationID applicationID, String cubeName, String axisName)
-	{
-		NCube cube = NCubeManager.getCube(applicationID, cubeName)
-        Set values = new LinkedHashSet()
-        Axis axis = cube.getAxis(axisName)
-        if (axis)
-        {
-            for (Column column : axis.columnsWithoutDefault)
-            {
-                values.add(column.value)
-            }
-        }
-		return values
-	}
-
-	private static Set<String> getAllVersions(String tenant, String app)
-	{
-		Map<String, List<String>> versionsMap = NCubeManager.getVersions(tenant, app)
-		Set<String> versions = new TreeSet<>(new VersionComparator())
-		versions.addAll(versionsMap[ReleaseStatus.RELEASE.name()])
-		versions.addAll(versionsMap[ReleaseStatus.SNAPSHOT.name()])
-		return versions
-	}
-
-	private String getAvailableScopeValuesMessage(VisualizerInfo visInfo, String cubeName, String key)
-	{
-		String messageScopeValues = ''
-		Set<Object> scopeValues = visInfo.availableScopeValues[key] ?: loadAvailableScopeValues(visInfo, cubeName, key)
+		Set<Object> scopeValues = visInfo.availableScopeValues[key] ?: visInfo.loadAvailableScopeValues(cubeName, key)
 		if (scopeValues) {
-			messageScopeValues = """\
-${DOUBLE_BREAK}The following values are available for ${key}: \
-${DOUBLE_BREAK}${scopeValues.join(COMMA_SPACE)}  """
+			StringBuilder sb = new StringBuilder()
+			sb.append("${BREAK}The following values are available for ${key}:${DOUBLE_BREAK}<pre><ul>")
+			scopeValues.each{
+				sb.append("<li>${it.toString()}</li>")
+			}
+			sb.append("</ul></pre>")
+			return sb.toString()
 		}
-		return messageScopeValues
+		return ''
 	}
 
 	private static String getMissingMinimumScopeMessage(Map<String, Object> scope, String messageScopeValues, String messageSuffixType, String messageSuffix )
@@ -622,7 +521,7 @@ ${DOUBLE_BREAK}${scopeValues.join(COMMA_SPACE)}  """
 The scope for the following scope keys was added since it was required: \
 ${DOUBLE_BREAK}${INDENT}${scope.keySet().join(COMMA_SPACE)}\
 ${DOUBLE_BREAK}${messageSuffixType} ${messageSuffix} \
-${messageScopeValues}"""
+${BREAK}${messageScopeValues}"""
 	}
 
 	private static String getExceptionMessage(VisualizerRelInfo relInfo, Throwable e, Throwable t)
@@ -633,21 +532,21 @@ ${DOUBLE_BREAK}<b>Message:</b> ${DOUBLE_BREAK}${e.message}${DOUBLE_BREAK}<b>Root
 ${DOUBLE_BREAK}${t.toString()}${DOUBLE_BREAK}<b>Stack trace: </b>${DOUBLE_BREAK}${t.stackTrace.toString()}"""
 	}
 
-	private String getCoordinateNotFoundMessage(VisualizerInfo visInfo, VisualizerRelInfo relInfo, String key, Object value, String cubeName)
+	private static String getCoordinateNotFoundMessage(VisualizerInfo visInfo, VisualizerRelInfo relInfo, String key, Object value, String cubeName)
 	{
 		String messageScopeValues = getAvailableScopeValuesMessage(visInfo, cubeName, key)
 		"""\
 The scope value ${value} for scope key ${key} cannot be found on axis ${key} in \
-cube ${cubeName}${relInfo.sourceMessage}. Please supply a different value for ${key}.\
+cube ${cubeName}${relInfo.sourceMessage}.${DOUBLE_BREAK} Please supply a different value for ${key}.${BREAK}\
 ${messageScopeValues}"""
 	}
 
-	private String getInvalidCoordinateExceptionMessage(VisualizerInfo visInfo, VisualizerRelInfo relInfo, Set<String> missingScope, String cubeName)
+	private static String getInvalidCoordinateExceptionMessage(VisualizerInfo visInfo, VisualizerRelInfo relInfo, Set<String> missingScope, String cubeName)
 	{
 		StringBuilder message = new StringBuilder()
 		message.append("""\
-Additional scope is required to load ${cubeName}${relInfo.sourceMessage}. Please add scope \
-value(s) for the following scope key(s): ${missingScope.join(COMMA_SPACE)}.""")
+Additional scope is required to load ${cubeName}${relInfo.sourceMessage}.${DOUBLE_BREAK} Please add scope \
+value(s) for the following scope key(s): ${missingScope.join(COMMA_SPACE)}.${BREAK}""")
 
 		missingScope.each{ String key ->
 			message.append(getAvailableScopeValuesMessage(visInfo, cubeName, key))

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -1,8 +1,15 @@
 package com.cedarsoftware.util
 
+import com.cedarsoftware.ncube.ApplicationID
+import com.cedarsoftware.ncube.Axis
+import com.cedarsoftware.ncube.Column
+import com.cedarsoftware.ncube.NCube
+import com.cedarsoftware.ncube.NCubeManager
+import com.cedarsoftware.ncube.ReleaseStatus
+import com.cedarsoftware.ncube.util.VersionComparator
 import groovy.transform.CompileStatic
 
-import static com.cedarsoftware.util.VisualizerConstants.DEFAULT_SCOPE_VALUE
+import static com.cedarsoftware.util.VisualizerConstants.*
 
 /**
  * Holds information related to the visualization of cubes and their relationships.
@@ -11,21 +18,41 @@ import static com.cedarsoftware.util.VisualizerConstants.DEFAULT_SCOPE_VALUE
 @CompileStatic
 class VisualizerInfo
 {
+    ApplicationID appId
 	String startCubeName
 	Map<String, Object> scope
-	List<Map<String, Object>> nodes
-	List<Map<String, String>> edges
+	List<Map<String, Object>> nodes = []
+	List<Map<String, Object>> edges = []
 
-	long maxLevel
-	long nodeCount
+	long maxLevel = 1
+	long nodeCount  = 1
 	long selectedLevel
+    boolean loadTraits = false
 
 	Map<String,String> allGroups
-	Set<String> selectedGroups
-	Set<String> availableGroupsAllLevels
-	String groupSuffix
+    String groupSuffix
+
+    Set<String> selectedGroups
+	Set<String> availableGroupsAllLevels = [] as Set
 	Set<String> availableScopeKeys = []
 	Map<String, Set<Object>> availableScopeValues = [:]
+    Map<String, Set<String>> requiredScopeKeys = [:]
+    Map<String, Set<String>> optionalScopeKeys = [:]
+
+    VisualizerInfo(ApplicationID applicationID, Map options)
+    {
+        appId = applicationID
+        startCubeName = options.startCubeName as String
+        scope = options.scope as CaseInsensitiveMap
+        selectedGroups = options.selectedGroups as Set ?: ALL_GROUPS_KEYS
+        String selectedLevel = options.selectedLevel as String
+        this.selectedLevel = selectedLevel == null ? DEFAULT_LEVEL : Converter.convert(selectedLevel, long.class) as long
+        availableScopeKeys =  options.availableScopeKeys as Set ?: DEFAULT_AVAILABLE_SCOPE_KEYS
+        availableScopeValues = options.availableScopeValues as Map ?: loadAvailableScopeValues()
+        loadTraits = options.loadTraits as boolean
+        allGroups = ALL_GROUPS_MAP
+        groupSuffix = _ENUM
+    }
 
 	void trimSelectedLevel()
 	{
@@ -64,5 +91,64 @@ class VisualizerInfo
             messages << "Scope is required for ${key}. ${messageSuffix}".toString()
         }
         return missingScope
+    }
+
+    Map<String, Set<Object>> loadAvailableScopeValues()
+    {
+        Map<String, Set<Object>> valuesByKey = new CaseInsensitiveMap<>()
+
+        //Values for Risk, SourceRisk, Coverage, SourceCoverage, etc.
+        DERIVED_SCOPE_KEYS.each { String key ->
+            String cubeName = RPM_SCOPE_CLASS_DOT + key + DOT_TRAITS
+            Set<Object> values = getColumnValues(appId, cubeName, key)
+            valuesByKey[key] = values
+            valuesByKey[SOURCE_SCOPE_KEY_PREFIX + key] = values
+        }
+
+        //Values for effective version
+        valuesByKey[EFFECTIVE_VERSION] = getAllVersions(appId.tenant, appId.app) as Set<Object>
+
+        //Values from ENT.APP
+        String latest = NCubeManager.getLatestVersion(ApplicationID.DEFAULT_TENANT, ENT_APP, ReleaseStatus.RELEASE.name())
+        ApplicationID entAppAppId = new ApplicationID(ApplicationID.DEFAULT_TENANT, ENT_APP, latest, ReleaseStatus.RELEASE.name(), ApplicationID.HEAD)
+
+        valuesByKey[BUSINESS_DIVISION_CODE] = getColumnValues(entAppAppId, BUSINESS_DIVISION_CUBE_NAME, BUSINESS_DIVISION_CODE)
+        Set<Object> stateValues = getColumnValues(entAppAppId, STATE_CUBE_NAME, STATE)
+        valuesByKey[STATE] = stateValues
+        valuesByKey[LOCATION_STATE] = stateValues
+
+        return valuesByKey
+    }
+
+    Set<Object> loadAvailableScopeValues(String cubeName, String key)
+    {
+        Set<Object> values = getColumnValues(appId, cubeName, key)
+        availableScopeValues[key] = values
+        return values
+    }
+
+
+    private static Set<Object> getColumnValues(ApplicationID applicationID, String cubeName, String axisName)
+    {
+        NCube cube = NCubeManager.getCube(applicationID, cubeName)
+        Set values = new LinkedHashSet()
+        Axis axis = cube.getAxis(axisName)
+        if (axis)
+        {
+            for (Column column : axis.columnsWithoutDefault)
+            {
+                values.add(column.value)
+            }
+        }
+        return values
+    }
+
+    private static Set<String> getAllVersions(String tenant, String app)
+    {
+        Map<String, List<String>> versionsMap = NCubeManager.getVersions(tenant, app)
+        Set<String> versions = new TreeSet<>(new VersionComparator())
+        versions.addAll(versionsMap[ReleaseStatus.RELEASE.name()])
+        versions.addAll(versionsMap[ReleaseStatus.SNAPSHOT.name()])
+        return versions
     }
 }

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -56,3 +56,9 @@ div.col-width-large {
     -ms-user-select: initial;
     user-select: initial;
 }
+
+ul, li{
+    list-style-position: inside;
+    margin: 0;
+    padding: 0;
+}

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -68,6 +68,12 @@
                         </div>
                     </div>
 
+                    <div id="loadTraits-div" class="inline-block">
+                        <div class="input-group input-group-sm">
+                            <input id="loadTraits" type="checkbox"> Include traits for all nodes (slower, requires re-load)
+                        </div>
+                    </div>
+
                     <div>
                         <div class="inline-block">
                             <label>Include: </label>


### PR DESCRIPTION
1. Add ability to load entire graph with all traits.
2. Add ability to load an individual node with all traits.
3. Visualizer is no longer extending NCubeGroovyController.
4. Better formatting of list of available scope values in toast messages.
5. Better formatting of lists in right-side info pane of visualizer.
6. For non-EPM classes where no scope is missing, load up the visualizer without the initial scope prompt.
7. Move methods from Visualizer to VisualizerInfo and VisualizerRelInfo.
8. Add constructors for VisualizerInfo and VisualizerRelInfo.