### PR TITLE
Visualizer: Changes to handling of scope in js

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -367,12 +367,12 @@ class Visualizer
 		if (NCubeManager.getCube(appId, cubeName).getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
 		{
 			String type = getTypeFromCubeName(cubeName)
-			String messageSuffixTypeScopeKey = "${DOUBLE_BREAK}Please replace ${DEFAULT_SCOPE_VALUE} for ${type} with an actual scope value.${BREAK}"
+			String messageSuffixTypeScopeKey = "${DOUBLE_BREAK}Please replace ${DEFAULT_SCOPE_VALUE} for ${type} with an actual scope value."
 			String messageScopeValues = getAvailableScopeValuesMessage(visInfo, cubeName, type)
 			String messageSuffix = 'The other default scope values may also be changed as desired.'
 			if (scope)
 			{
-				hasMissingScope = visInfo.addMissingMinimumScope(type, DEFAULT_SCOPE_VALUE, messageSuffixTypeScopeKey + messageScopeValues, messages) ?: hasMissingScope
+				hasMissingScope = visInfo.addMissingMinimumScope(type, DEFAULT_SCOPE_VALUE, "${messageSuffixTypeScopeKey}${messageScopeValues}", messages) ?: hasMissingScope
 				hasMissingScope = visInfo.addMissingMinimumScope(POLICY_CONTROL_DATE, defaultScopeDate, messageSuffixScopeKey, messages) ?: hasMissingScope
 				hasMissingScope = visInfo.addMissingMinimumScope(QUOTE_DATE, defaultScopeDate, messageSuffixScopeKey, messages) ?: hasMissingScope
 				hasMissingScope = visInfo.addMissingMinimumScope(EFFECTIVE_VERSION, defaultScopeEffectiveVersion, messageSuffixScopeKey, messages) ?: hasMissingScope
@@ -520,7 +520,7 @@ class Visualizer
 		"""\
 The scope for the following scope keys was added since it was required: \
 ${DOUBLE_BREAK}${INDENT}${scope.keySet().join(COMMA_SPACE)}\
-${DOUBLE_BREAK}${messageSuffixType} ${messageSuffix} \
+${messageSuffixType} ${messageSuffix} \
 ${BREAK}${messageScopeValues}"""
 	}
 


### PR DESCRIPTION
1. Scope is now saved off to local storage and available when re-opening the cube for visualization or using the back button to navigate back to a visualization.

2. Fixed issues with the scope picker. It is now displaying already picked scope keys and is able to add scope keys.
            TODO: The key in the scope picker is case sensitive, which doesn’t play well with the case insensitive scope that comes across from the server (Product vs. product, etc.).
            TODO: When a key is picked in the scope picker, make the value a drop-down populated with available scope values.

3. Added temporary code to handle cube names with "_" instead of "." (e.g. rpm_class_product instead of rpm.class.product) in nce.getSelectedCubeName()after a page refresh (not always, but often).

            TODO: Figure out what the deal is here and find a permanent solution.