### PR TITLE
Visualizer: Optimize trim of network data in js

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -67,7 +67,6 @@ class Visualizer
 	 *            Map scope, the context for which the visualizer is loaded
 	 *            Set<String> availableScopeKeys, scope keys available in the visualization
 	 *            Map<String, Set<Object>> availableScopeValues, scope values available in the visualization, by scope key
-	 *            boolean loadTraits, whether to load and display traits
 	 * @return node
      */
 	Map getTraits(ApplicationID applicationID, Map options)

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -46,7 +46,7 @@ class VisualizerRelInfo
 		targetLevel = Long.valueOf(node.level as String)
 		targetScope = node.scope as CaseInsensitiveMap
 		scope = node.availableScope as CaseInsensitiveMap
-		loadTraits = options.loadTraits as boolean
+		loadTraits = node.loadTraits as boolean
 		group = setGroupName()
 	}
 
@@ -346,19 +346,14 @@ class VisualizerRelInfo
 		edge.toName = targetCubeEffectiveName
 		edge.fromFieldName = sourceFieldName
 		edge.level = String.valueOf(targetLevel)
-		edge.label = ''
+		if (targetCube.name.startsWith(RPM_ENUM_DOT))
+		{
+			edge.label = sourceFieldName
+		}
 		Map<String, Map<String, Object>> sourceFieldTraitMap = sourceTraitMaps[sourceFieldName] as Map
-		String vMin = sourceFieldTraitMap[V_MIN]
-		String vMax = sourceFieldTraitMap[V_MAX]
-
-		if (vMin != null && vMax != null)
-		{
-			edge.title = "${vMin}:${vMax}"
-		}
-		else
-		{
-			edge.title = ''
-		}
+		String vMin = sourceFieldTraitMap[V_MIN] as String ?: '0'
+		String vMax = sourceFieldTraitMap[V_MAX] as String ?: '999999'
+		edge.title = "Field ${sourceFieldName} with min:max cardinality of ${vMin}:${vMax}".toString()
 		return edge
 	}
 
@@ -375,11 +370,22 @@ class VisualizerRelInfo
 		node.scope = targetScope
 		node.availableScope = scope
 		node.fromFieldName = sourceFieldName == null ? null : sourceFieldName
-		node.title = targetCubeName
+		if (targetCubeName.startsWith(RPM_CLASS_DOT))
+		{
+			node.title = "${targetCubeName} for ${getDotSuffix(targetEffectiveName)}".toString()
+		}
+		else
+		{
+			node.title = "${targetCubeName} for field ${sourceFieldName}".toString()
+		}
 		node.desc = title
 		group ?: setGroupName()
-		node.label = label
+		if (targetCubeName.startsWith(RPM_CLASS_DOT))
+		{
+			node.label = label
+		}
 		node.group = nodeGroup
+		node.loadTraits = loadTraits
 		return node
 	}
 

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -38,8 +38,7 @@
                     <div id="scope-div" class="inline-block">
                         <div class="input-group input-group-sm col-width-large">
                             <input id="scope" type="text" placeholder="Loading scope...">
-                            <button id="scopeBuilderOpen" class="btn btn-default btn-xs">...</button>
-                        </div>
+                            <button id="scopeBuilderOpen" class="btn btn-default btn-xs">...</button></div>
                     </div>
 
                     <div id="load-div" class="inline-block">
@@ -87,12 +86,17 @@
 
                     <div>
                         <div class="inline-block">
-                            <label>Include: </label>
+                            <label>Groups: </label>
                         </div>
                         <div id="availableGroupsAllLevels-div" class="inline-block" >
                             <div>
-                                <div id="availableGroupsAllLevels" class="input-group input-group-sm">Loading included groups...
+                                <div id="availableGroupsAllLevels" class="input-group input-group-sm">Loading groups...
                                 </div>
+                            </div>
+                        </div>
+                        <div id="refreshGroups-div" class="inline-block">
+                            <div class="input-group input-group-sm">
+                                <button id="refreshGroups" class="btn btn-primary btn-xs">Refresh</button>
                             </div>
                         </div>
                     </div>

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -36,19 +36,19 @@
                         <label>Scope: </label>
                     </div>
                     <div id="scope-div" class="inline-block">
-                        <div class="input-group input-group-sm col-width-large">
-                            <input id="scope" type="text" placeholder="Loading scope...">
+                        <div class="input-group input-group-sm col-width-large" title="Scope used to load graph data from n-cube class definitions">
+                            <input id="scope" type="text" placeholder="Loading scope..." >
                             <button id="scopeBuilderOpen" class="btn btn-default btn-xs">...</button></div>
                     </div>
 
                     <div id="load-div" class="inline-block">
-                        <div class="input-group input-group-sm">
+                        <div class="input-group input-group-sm" title="Load graph data from n-cube class definitions">
                             <button id="loadGraph" class="btn btn-primary btn-xs">Load</button>
                          </div>
                     </div>
 
-                    <div id="reload-div" class="inline-block">
-                        <div class="input-group input-group-sm">
+                    <div id="reset-div" class="inline-block">
+                        <div class="input-group input-group-sm" title="Reset scope and other graph inputs to defaults">
                              <button id="reset" class="btn btn-primary btn-xs">Reset</button>
                         </div>
                     </div>
@@ -61,7 +61,7 @@
                         <label>Levels: </label>
                     </div>
                     <div id="selectedLevel-div" class="inline-block">
-                        <div class="input-group input-group-sm">
+                        <div class="input-group input-group-sm" title="Show nodes up to and including this level of depth in the graph">
                             <select id="selectedLevel-list" class="form-control">
                                 <option>Loading levels...</option>
                             </select>
@@ -73,13 +73,13 @@
                     </div>
 
                     <div id="hierarchical-div" class="inline-block">
-                        <div class="input-group input-group-sm">
+                        <div class="input-group input-group-sm" title="Show a hierarchical view of the graph">
                             <input id="hierarchical" type="checkbox"> Hierarchical
                         </div>
                     </div>
 
                     <div id="loadTraits-div" class="inline-block">
-                        <div class="input-group input-group-sm">
+                        <div class="input-group input-group-sm" title="Include traits for all nodes. A faster alternative is to load traits for select nodes (click a node and then click 'Show Traits' in right-hand info pane).">
                             <input id="loadTraits" type="checkbox"> Include traits for all nodes (slower, requires re-load)
                         </div>
                     </div>
@@ -88,14 +88,14 @@
                         <div class="inline-block">
                             <label>Groups: </label>
                         </div>
-                        <div id="availableGroupsAllLevels-div" class="inline-block" >
+                        <div id="availableGroupsAllLevels-div" class="inline-block" title="Show/hide group in the graph">
                             <div>
                                 <div id="availableGroupsAllLevels" class="input-group input-group-sm">Loading groups...
                                 </div>
                             </div>
                         </div>
                         <div id="refreshGroups-div" class="inline-block">
-                            <div class="input-group input-group-sm">
+                            <div class="input-group input-group-sm" title="Refresh view of graph for included/excluded groups">
                                 <button id="refreshGroups" class="btn btn-primary btn-xs">Refresh</button>
                             </div>
                         </div>
@@ -111,10 +111,10 @@
        </div>
     </div>
 
-    <div id="visLayoutEast" class="pane ui-layout-east" title="Tests" aria-disabled="false">
-        <h3 id="nodeTitle"></h3>
-        <div id="nodeVisualizer"></div>
-        <div id="nodeTraits"></div>
+    <div id="visLayoutEast" class="pane ui-layout-east" aria-disabled="false">
+        <h3 id="nodeTitle" title="Link to n-cube view of class"></h3>
+        <div id="nodeVisualizer" title="Link to new visualization with this class as the starting point"></div>
+        <div id="nodeTraits" title="Show or hide traits for the class"></div>
         <div id="nodeDesc"></div>
     </div>
 

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -39,7 +39,18 @@
                         <div class="input-group input-group-sm col-width-large">
                             <input id="scope" type="text" placeholder="Loading scope...">
                             <button id="scopeBuilderOpen" class="btn btn-default btn-xs">...</button>
+                        </div>
+                    </div>
+
+                    <div id="load-div" class="inline-block">
+                        <div class="input-group input-group-sm">
                             <button id="loadGraph" class="btn btn-primary btn-xs">Load</button>
+                         </div>
+                    </div>
+
+                    <div id="reload-div" class="inline-block">
+                        <div class="input-group input-group-sm">
+                             <button id="reset" class="btn btn-primary btn-xs">Reset</button>
                         </div>
                     </div>
 

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -189,7 +189,6 @@ var Visualizer = (function ($) {
     {
         var options =
         {
-            loadTraits: true,
             node: node,
             scope: _scope,
             availableScopeKeys: _availableScopeKeys,
@@ -219,7 +218,9 @@ var Visualizer = (function ($) {
             _availableScopeKeys = visInfo.availableScopeKeys['@items'].sort();
             replaceNode(_nodes, node)
             _nodeDesc[0].innerHTML = node.desc;
-            draw();
+            _nodeTraits = $('#nodeTraits');
+            _nodeTraits[0].innerHTML = '';
+            _nodeTraits.append(createTraitsLink(node));
          }
         else {
             var message = json.message;
@@ -516,6 +517,14 @@ var Visualizer = (function ($) {
         for (var i = 0, iLen = _nodes.length; i < iLen; i++)
         {
             var node  = _nodes[i];
+
+            if (node.id === '1')
+            {
+                node.shapeProperties = {borderDashes:  [15,5]};
+                node.borderWidth = 3;
+                node.scaling = {min: 70, max: 70, label: {enabled: true}};
+            }
+
             var selectedGroup = isSelectedGroup(node);
 
             if (parseInt(node.level) > level)
@@ -542,12 +551,12 @@ var Visualizer = (function ($) {
         }
 
         //given the selected level, determine edges to exclude
-        for (var k = 0, kLen = _edges.length; k < kLen; k++)
-        {
-            var edge  = _edges[k];
-            if (parseInt(edge.level) > level)
-            {
-                _excludedEdgeIdList.push(edge.id);
+        if (_edges) {
+            for (var k = 0, kLen = _edges.length; k < kLen; k++) {
+                var edge = _edges[k];
+                if (parseInt(edge.level) > level) {
+                    _excludedEdgeIdList.push(edge.id);
+                }
             }
         }
         _selectedGroups = selectedGroups;
@@ -723,54 +732,67 @@ var Visualizer = (function ($) {
                 },
                 PRODUCT_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 RISK_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 COVERAGE_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 LIMIT_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 PREMIUM_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 RATE_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 RATEFACTOR_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 ROLE_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 ROLEPLAYER_ENUM : {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 CONTAINER_ENUM: {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 DEDUCTIBLE_ENUM: {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 PARTY_ENUM: {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 },
                 PLACE_ENUM: {
                     shape: 'dot',
+                    scaling: {min: 5, max: 5},
                     color: 'gray'   // gray
                 }
             }
@@ -802,27 +824,11 @@ var Visualizer = (function ($) {
                 _nodeTitle[0].innerHTML = 'Class ';
                 _nodeTitle.append(cubeLink);
 
-                var visualizerLink = $('<a/>');
-                visualizerLink.addClass('nc-anc');
-                visualizerLink.html('visualize');
-                visualizerLink.click(function (e) {
-                    e.preventDefault();
-                    _keepCurrentScope = true;
-                    _scope = node.scope;
-                    _nce.selectCubeByName(cubeName, appId, TAB_VIEW_TYPE_VISUALIZER + PAGE_ID);
-                 });
                 _nodeVisualizer[0].innerHTML = '';
-                _nodeVisualizer.append(visualizerLink);
+                _nodeVisualizer.append(createVisualizeFromHereLink(appId, cubeName, node));
 
-                var traitsLink = $('<a/>');
-                traitsLink.addClass('nc-anc');
-                traitsLink.html('load traits<BR><BR>');
-                traitsLink.click(function (e) {
-                    e.preventDefault();
-                    loadTraits(node);
-                  });
                 _nodeTraits[0].innerHTML = '';
-                _nodeTraits.append(traitsLink);
+                _nodeTraits.append(createTraitsLink(node));
 
                 _nodeDesc[0].innerHTML = node.desc;
                 _layout.open('east');
@@ -838,6 +844,37 @@ var Visualizer = (function ($) {
                 }
             }
         });
+    }
+
+    function createVisualizeFromHereLink(appId, cubeName, node)
+    {
+        var visualizerLink = $('<a/>');
+        visualizerLink.addClass('nc-anc');
+        visualizerLink.html('new visual from here');
+        visualizerLink.click(function (e) {
+            e.preventDefault();
+            _keepCurrentScope = true;
+            _scope = node.scope;
+            _nce.selectCubeByName(cubeName, appId, TAB_VIEW_TYPE_VISUALIZER + PAGE_ID);
+        });
+        return visualizerLink;
+    }
+
+    function createTraitsLink(node) {
+        var traitsLink = $('<a/>');
+        traitsLink.addClass('nc-anc');
+        if (node.loadTraits) {
+            traitsLink.html('hide traits<BR><BR>');
+        }
+        else {
+            traitsLink.html('show traits<BR><BR>');
+        }
+        traitsLink.click(function (e) {
+            e.preventDefault();
+            node.loadTraits = !node.loadTraits;
+            loadTraits(node);
+        });
+        return traitsLink;
     }
 
     function replaceNode(nodes, newNode) {

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -130,7 +130,11 @@ var Visualizer = (function ($) {
                 _reset = true;
                 load();
             });
-        }
+
+            $('#refreshGroups').click(function () {
+                reload();
+            });
+         }
     };
 
     function updateScopeBuilderScope()
@@ -420,9 +424,7 @@ var Visualizer = (function ($) {
             }
         }
 
-        if (groupCurrentlyAvailable(group)){
-            reload();
-        }
+        groupCurrentlyAvailable(group)
     }
 
     function groupCurrentlyAvailable(group){
@@ -440,10 +442,8 @@ var Visualizer = (function ($) {
         if (group.checked && !currentlyIncluded) {
             var groupIdPrefix = group.id.split(_groupSuffix)[0];
             var levelLabel = _selectedLevel === 1 ? 'level' : 'levels';
-            _nce.showNote('The group ' + groupIdPrefix + ' is not included in the ' + _selectedLevel + ' ' + levelLabel + ' currently displayed. Increase the levels to include the group.', 'Note', 5000);
+            _nce.showNote('The group ' + groupIdPrefix + ' is not included in the ' + _selectedLevel + ' ' + levelLabel + ' currently displayed. Increase the levels to include the group.', 'Note', 3000);
         }
-
-        return currentlyIncluded
     }
 
     function groupIdsEqual(groupId1, groupId2)

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -29,6 +29,7 @@ var Visualizer = (function ($) {
     var _edges = null;
     var _scope = null;
     var _keepCurrentScope = false;
+    var _reset = false;
     var _availableScopeKeys = [];
     var _selectedGroups = null;
     var _availableGroupsAtLevel = null;
@@ -122,7 +123,12 @@ var Visualizer = (function ($) {
             });
 
             $('#loadGraph').click(function () {
-                load()
+                load();
+            });
+
+            $('#reset').click(function () {
+                _reset = true;
+                load();
             });
         }
     };
@@ -238,14 +244,19 @@ var Visualizer = (function ($) {
 
         if (_keepCurrentScope)
         {
-            _keepCurrentScope = false
+            _keepCurrentScope = false;
+        }
+        else if (_reset)
+        {
+            _scope = null;
+            _reset = false;
         }
         else{
             _scope = getSavedScope();
         }
 
          
-        if (_selectedCubeName !== _loadedCubeName)
+        if (_reset || _selectedCubeName !== _loadedCubeName)
         {
             _selectedLevel = null;
             _selectedGroups = null;

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -23,6 +23,7 @@ var Visualizer = (function ($) {
     var _network = null;
     var _nce = null;
     var _loadedCubeName = null;
+    var _loadedAppId = null;
     var _excludedNodeIdList = null;
     var _excludedEdgeIdList = null;
     var _nodes = null;
@@ -259,7 +260,12 @@ var Visualizer = (function ($) {
             _scope = getSavedScope();
         }
 
-         
+        if (_loadedAppId && !appIdMatch(_loadedAppId, _nce.getSelectedTabAppId()))
+        {
+            _availableScopeKeys = null;
+            _availableScopeValues = null;
+        }
+
         if (_reset || _selectedCubeName !== _loadedCubeName)
         {
             _selectedLevel = null;
@@ -337,6 +343,14 @@ var Visualizer = (function ($) {
             _scopeBuilderListenersAdded = true;
         }
     };
+
+    function appIdMatch(appIdA, appIdB)
+    {
+        return appIdA.appId === appIdB.appId &&
+            appIdA.version === appIdB.version &&
+            appIdA.status ===  appIdB.status &&
+            appIdA.branch === appIdB.branch;
+    }
 
     function clearVisLayoutEast(){
         _nodeTitle[0].innerHTML = '';
@@ -557,6 +571,7 @@ var Visualizer = (function ($) {
         delete _scope['@type'];
         delete _scope['@id'];
         _loadedCubeName = _selectedCubeName;
+        _loadedAppId = _nce.getSelectedTabAppId();
         _availableScopeValues = visInfo.availableScopeValues;
         _availableScopeKeys = visInfo.availableScopeKeys['@items'].sort();
      }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -23,15 +23,10 @@ var Visualizer = (function ($) {
     var _network = null;
     var _nce = null;
     var _loadedCubeName = null;
-    var _nodesAllLevels = null;
-    var _edgesAllLevels = null;
-    var _nodesAtLevel = null;
-    var _edgesAtLevel = null;
-    var _nodesAboveLevel = null;
-    var _edgesAboveLevel = null;
+    var _excludedNodeIdList = null;
+    var _excludedEdgeIdList = null;
     var _nodes = null;
     var _edges = null;
-    var _networkData = null;
     var _scope = null;
     var _keepCurrentScope = false;
     var _availableScopeKeys = [];
@@ -105,8 +100,9 @@ var Visualizer = (function ($) {
                 }
             });
 
-            $('#selectedLevel-list').change(function () {
-                reload($('#selectedLevel-list').val());
+             $('#selectedLevel-list').change(function () {
+                _selectedLevel = $('#selectedLevel-list').val()
+                reload();
             });
 
             $('#hierarchical').change(function () {
@@ -168,8 +164,8 @@ var Visualizer = (function ($) {
         return newScope;
     }
 
-    var reload = function (level) {
-        trimNetworkData(level);
+    var reload = function () {
+        setGroupsAndExcluded();
         draw();
         loadSelectedLevelListView();
         loadAvailableGroupsView();
@@ -285,8 +281,8 @@ var Visualizer = (function ($) {
             if (json.message !== null) {
                 _nce.showNote(json.message);
             }
-            loadNetworkData(json.visInfo, json.status);
-            trimNetworkData(null);
+            loadData(json.visInfo, json.status);
+            setGroupsAndExcluded();
             draw();
             loadSelectedLevelListView();
             saveScope();
@@ -302,7 +298,7 @@ var Visualizer = (function ($) {
         }
         else if (json.status === STATUS_MISSING_START_SCOPE) {
             _nce.showNote(json.message);
-            loadNetworkData(json.visInfo, json.status);
+            loadData(json.visInfo, json.status);
             saveScope();
             updateScopeBuilderScope();
             loadScopeView();
@@ -414,7 +410,7 @@ var Visualizer = (function ($) {
         }
 
         if (groupCurrentlyAvailable(group)){
-            reload(_selectedLevel);
+            reload();
         }
     }
 
@@ -471,118 +467,69 @@ var Visualizer = (function ($) {
     function getVisNetworkHeight() {
         return  '' + ($(this).height() - $('#network').offset().top);
     }
-
-    function trimNetworkData(level)
+    
+    function isSelectedGroup(node)
     {
-        var selectedGroups = [];
-        var availableGroupsAtLevel = [];
-        var nodes = [];
-        var edges = [];
-        var nodesAtLevel = [];
-        var edgesAtLevel = [];
-        var nodesAboveLevel = [];
-        var edgesAboveLevel = [];
-        var nodesToProcess = [];
-        var edgesToProcess = [];
-
-        var levelInt = null;
-        if (level !=null) {
-            levelInt = parseInt(level);
-        }
-        var selectedLevelInt = parseInt(_selectedLevel);
-
-        //determine which nodes and edges to process
-        if (levelInt === null) {
-            level =  _selectedLevel;
-            levelInt =  selectedLevelInt;
-            Array.prototype.push.apply(nodesToProcess, _nodesAllLevels);
-            Array.prototype.push.apply(edgesToProcess, _edgesAllLevels);
-        }
-        else if (levelInt <= selectedLevelInt){
-            Array.prototype.push.apply(nodesToProcess, _nodesAtLevel);
-            Array.prototype.push.apply(edgesToProcess, _edgesAtLevel);
-            Array.prototype.push.apply(nodesAboveLevel, _nodesAboveLevel);
-            Array.prototype.push.apply(edgesAboveLevel, _edgesAboveLevel);
-        }
-        else if (levelInt > selectedLevelInt){
-            Array.prototype.push.apply(nodesToProcess, _nodesAboveLevel);
-            Array.prototype.push.apply(edgesToProcess, _edgesAboveLevel);
-            Array.prototype.push.apply(nodes, _nodesAtLevel);
-            Array.prototype.push.apply(edges, _edgesAtLevel);
-            Array.prototype.push.apply(nodesAtLevel, _nodesAtLevel);
-            Array.prototype.push.apply(edgesAtLevel, _edgesAtLevel);
-        }
-
-        //collect nodes
-        for (var i = 0, iLen = nodesToProcess.length; i < iLen; i++)
+        for (var j = 0, jLen = _selectedGroups.length; j < jLen; j++)
         {
-            var isSelectedGroup = false;
-            var node  = nodesToProcess[i];
-
-            for (var j = 0, jLen = _selectedGroups.length; j < jLen; j++)
-            {
-                if (groupIdsEqual(node.group, _selectedGroups[j])){
-                    isSelectedGroup = true;
-                    break;
-                }
-            }
-
-            if (parseInt(node.level) <= levelInt) {
-                nodesAtLevel.push(node);
-                if (isSelectedGroup ) {
-                    nodes.push(node);
-                }
-            } else {
-                nodesAboveLevel.push(node);
+            if (groupIdsEqual(node.group, _selectedGroups[j])){
+                return true;
             }
         }
-
-        //collect edges
-        for (var k = 0, kLen = edgesToProcess.length; k < kLen; k++)
-        {
-            var edge  = edgesToProcess[k];
-
-            if (parseInt(edge.level) <= levelInt) {
-                edges.push(edge);
-                edgesAtLevel.push(edge);
-            } else {
-                edgesAboveLevel.push(edge);
-            }
-        }
-
-        //collect available groups at level
-        for (var l = 0, lLen = nodesAtLevel.length; l < lLen; l++) {
-            var nodeAtLevel = nodesAtLevel[l];
-            var groupNamePrefix = nodeAtLevel.group.replace(_groupSuffix, '');
-            if (availableGroupsAtLevel.indexOf(groupNamePrefix) == -1) {
-                availableGroupsAtLevel.push(groupNamePrefix);
-            }
-        }
-
-        for (var m = 0, mLen = nodes.length; m < mLen; m++)
-        {
-            var node = nodes[m];
-            var groupNamePrefix = node.group.replace(_groupSuffix, '');
-            if (_selectedGroups.indexOf(groupNamePrefix) > -1 && selectedGroups.indexOf(groupNamePrefix) === -1) {
-                selectedGroups.push(groupNamePrefix);
-            }
-        }
-
-        _nodesAtLevel = nodesAtLevel;
-        _edgesAtLevel = edgesAtLevel;
-        _nodesAboveLevel = nodesAboveLevel;
-        _edgesAboveLevel = edgesAboveLevel;
-
-        _selectedGroups = selectedGroups;
-        _availableGroupsAtLevel = availableGroupsAtLevel;
-        _selectedLevel = level;
-
-        _nodes = nodes;
-        _edges = edges;
-        _networkData = {nodes:nodes, edges:edges};
+        return false;
     }
 
-    function loadNetworkData(visInfo, status) {
+    function setGroupsAndExcluded()
+    {
+        _excludedNodeIdList = [];
+        _excludedEdgeIdList = [];
+        var selectedGroups = [];
+        var availableGroupsAtLevel = [];
+        var   level = parseInt(_selectedLevel);
+        
+        //given the selected level, determine nodes to exclude, selected groups and available groups 
+        for (var i = 0, iLen = _nodes.length; i < iLen; i++)
+        {
+            var node  = _nodes[i];
+            var selectedGroup = isSelectedGroup(node);
+
+            if (parseInt(node.level) > level)
+            {
+                _excludedNodeIdList.push(node.id);
+            }
+            else {
+                if (selectedGroup) {
+                    //collect selected groups at level
+                    var groupNamePrefix = node.group.replace(_groupSuffix, '');
+                    if (_selectedGroups.indexOf(groupNamePrefix) > -1 && selectedGroups.indexOf(groupNamePrefix) === -1) {
+                        selectedGroups.push(groupNamePrefix);
+                    }
+                }
+                else{
+                    _excludedNodeIdList.push(node.id);
+                }
+                //collect available groups at level
+                var groupNamePrefix = node.group.replace(_groupSuffix, '');
+                if (availableGroupsAtLevel.indexOf(groupNamePrefix) == -1) {
+                    availableGroupsAtLevel.push(groupNamePrefix)
+                }
+            }
+        }
+
+        //given the selected level, determine edges to exclude
+        for (var k = 0, kLen = _edges.length; k < kLen; k++)
+        {
+            var edge  = _edges[k];
+            if (parseInt(edge.level) > level)
+            {
+                _excludedEdgeIdList.push(edge.id);
+            }
+        }
+        _selectedGroups = selectedGroups;
+        _availableGroupsAtLevel = availableGroupsAtLevel;
+    }
+
+    function loadData(visInfo, status) {
 
         if (status === STATUS_SUCCESS) {
             _allGroups = visInfo.allGroups;
@@ -592,8 +539,8 @@ var Visualizer = (function ($) {
             _groupSuffix = visInfo.groupSuffix;
             _nodeCount = visInfo.nodeCount;
             _maxLevel = visInfo.maxLevel;
-            _nodesAllLevels = visInfo.nodes['@items'];
-            _edgesAllLevels = visInfo.edges['@items'];
+            _nodes = visInfo.nodes['@items'];
+            _edges = visInfo.edges['@items'];
         }
         _scope = visInfo.scope;
         delete _scope['@type'];
@@ -613,7 +560,6 @@ var Visualizer = (function ($) {
     }
 
     function clusterDescendants(immediateDescendantsOnly) {
-        _network.setData(_networkData);
         for (var i = 0; i < _network.clusteredNodeIds.length; i++) {
             var id = _network.clusteredNodeIds[i];
             clusterDescendantsByNodeId(id, immediateDescendantsOnly);
@@ -808,16 +754,18 @@ var Visualizer = (function ($) {
             _network.destroy();
             _network = null;
         }
-        _network = new vis.Network(container, _networkData, options);
+        _network = new vis.Network(container, {nodes:_nodes, edges:_edges}, options);
+        _network.nodesHandler.remove(_excludedNodeIdList);
+        _network.edgesHandler.remove(_excludedEdgeIdList);
         customizeNetworkForNce(_network);
         _network.clusteredNodeIds = [];
 
         _network.on('select', function(params) {
-            var nodeId = params.nodes[0]
+            var nodeId = params.nodes[0];
             var node = getNodeById(_nodes, nodeId );
             if (node) {
                 var cubeName = node.name;
-                var appId =_nce.getSelectedTabAppId()
+                var appId =_nce.getSelectedTabAppId();
                 var cubeLink = $('<a/>');
                 cubeLink.addClass('nc-anc');
                 cubeLink.html(cubeName);


### PR DESCRIPTION
1. Renamed trimNetworkData method in visualizer.js to setGroupsAndExcluded. Also simplified the method a great deal. The lists of nodes and edges passed in to the visjs network is now the same as what the server returns (no new lists created, should help memory). The nodes and edges that we don’t want to include in the network (given the selected level and/or group) are instead removed from the network directly. This allows a huge graph to render faster (though still slow, with most of the time spent rendering the nodes in the browser after visualizer.js finishes up its processing; something to look into).

It also fixes a bug in the old trimNetworkData code that caused groups to be included in some cases even when not checked.

 It is now possible to render the highest level for the WC product graph, for example.

2. Added Reset button that resets scope and all other settings to defaults. 

3. Add Refresh button for “group” checkboxes. The screen no longer reloads after each check/uncheck, but only after user clicks Refresh.

4. Added check for “selected tab app id” matching the “loaded tab app id”. If not matching, clear out the available scope key and values lists that are passed back to the server side so that the server rebuilds the lists based on the new app id.

5.	Changed “Load traits” link in right-side info pane to say either “Show traits” or “Hide traits”. Now allows to either show or hide traits.

6.	Fixed bug that was causing v:min and v:max to not show on edges.

7.	Changed to show the field name on the edge going from a class to an enum or from a class to a class.

8.	Reduced the size of the grey dot that represents enums in the graph.

9.	Change format of the starting point node in the graph to stand out better (bigger and with a broken border).

10.	Added titles to html input elements in the graph to provide instructions to the user.
