### PR TITLE
Visualizer - change labels and remove class name prefixes

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -33,7 +33,6 @@ public final class VisualizerConstants
 	public static final String UNSPECIFIED = 'UNSPECIFIED'
 	public static final Map<String, String> ALL_GROUPS_MAP = [PRODUCT: 'Product', FORM: 'Form', RISK: 'Risk', COVERAGE: 'Coverage', CONTAINER: 'Container', DEDUCTIBLE: 'Deductible', LIMIT: 'Limit', RATE: 'Rate', RATEFACTOR: 'Rate Factor', PREMIUM: 'Premium', PARTY: 'Party', PLACE: 'Place', ROLE: 'Role', ROLEPLAYER: 'Role Player', UNSPECIFIED: 'Unspecified']
 	public static final Set<String> ALL_GROUPS_KEYS = ALL_GROUPS_MAP.keySet()
-	public static final String[] GROUPS_TO_SHOW_IN_TITLE = ['COVERAGE', 'DEDUCTIBLE', 'LIMIT', 'PREMIUM', 'PRODUCT', 'RATE', 'RATEFACTOR', 'RISK', 'ROLEPLAYER', 'ROLE']
 
 	public static final String EFFECTIVE_VERSION = '_effectiveVersion'
 	public static final String POLICY_CONTROL_DATE = 'policyControlDate'
@@ -63,13 +62,10 @@ public final class VisualizerConstants
 	public static final String COMMA_SPACE = ', '
 	public static final String DOUBLE_BREAK = "${BREAK}${BREAK}"
 
-	public static final int NODE_LABEL_MAX_LINE_LENGTH = 16
-	public static final double NODE_LABEL_LINE_LENGTH_MULTIPLIER = 1.2d
-
 	public static final Set<String> MANDATORY_RPM_SCOPE_KEYS = [AXIS_FIELD, AXIS_NAME, AXIS_TRAIT] as Set
-	public static final String MISSING_SCOPE = 'missing scope for '
-	public static final String UNABLE_TO_LOAD = 'unable to load '
-	public static final String SCOPE_VALUE_NOT_FOUND = 'scope value not found for '
+	public static final String MISSING_SCOPE = 'Missing scope for '
+	public static final String UNABLE_TO_LOAD = 'Unable to load '
+	public static final String SCOPE_VALUE_NOT_FOUND = 'Scope value not found for '
 
 	public static final String STATUS_MISSING_START_SCOPE = 'missingStartScope'
 	public static final String STATUS_SUCCESS = 'success'

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -346,19 +346,18 @@ class VisualizerRelInfo
 		node.availableScope = scope
 		node.fromFieldName = sourceFieldName == null ? null : sourceFieldName
 
+		String targetCubeDisplayName = getCubeDisplayName(targetCubeName)
+		node.cubeDisplayName = targetCubeDisplayName
 		if (targetCubeName.startsWith(RPM_CLASS_DOT))
 		{
 			String label = getDotSuffix(targetEffectiveName)
 			node.label = label
-			String cubeDisplayName = getCubeDisplayName(targetCubeName)
-			node.cubeDisplayName = cubeDisplayName
-			node.title = "${cubeDisplayName} - ${label}".toString()
+			node.title = "${targetCubeDisplayName} - ${label}".toString()
 		}
 		else
 		{
-			String cubeDisplayName = getCubeDisplayName(sourceCube.name)
-			node.cubeDisplayName = cubeDisplayName
-			node.title = "Valid values for field ${sourceFieldName} on ${cubeDisplayName}".toString()
+			String sourceCubeDisplayName = getCubeDisplayName(sourceCube.name)
+			node.title = "Valid values for field ${sourceFieldName} on ${sourceCubeDisplayName}".toString()
 		}
 		node.desc = description
 		group ?: setGroupName()

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -820,6 +820,7 @@ var Visualizer = (function ($) {
                         e.preventDefault();
                         _nce.selectCubeByName(cubeName, appId, TAB_VIEW_TYPE_NCUBE + PAGE_ID);
                     });
+                    _nodeTitle[0].innerHTML = '';
                     _nodeTitle.append(cubeLink);
 
                     _nodeVisualizer[0].innerHTML = '';

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -1042,7 +1042,10 @@ var Visualizer = (function ($) {
                 arrows: 'to',
                 color: 'gray',
                 smooth: true,
-                hoverWidth: 3
+                hoverWidth: 3,
+                font: {
+                    size: 20
+                }
             },
             physics: {
                 enabled: physicsEnabled

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -811,16 +811,15 @@ var Visualizer = (function ($) {
                 nodeId = params.nodes[0];
                 node = getNodeById(_nodes, nodeId );
                 if (node) {
-                    cubeName = node.name;
+                    cubeName = node.cubeName;
                     appId =_nce.getSelectedTabAppId();
                     cubeLink = $('<a/>');
                     cubeLink.addClass('nc-anc');
-                    cubeLink.html(cubeName);
+                    cubeLink.html(node.cubeDisplayName);
                     cubeLink.click(function (e) {
                         e.preventDefault();
                         _nce.selectCubeByName(cubeName, appId, TAB_VIEW_TYPE_NCUBE + PAGE_ID);
                     });
-                    _nodeTitle[0].innerHTML = 'Class ';
                     _nodeTitle.append(cubeLink);
 
                     _nodeVisualizer[0].innerHTML = '';


### PR DESCRIPTION

1.	Removed class name and dash line from node labels.
2.	Changed hover text for nodes to indicate class and scoped name (e.g. “Product – WorkersCompensationProduct”).
3.	Changed hover text for edges to indicate valid values for field on class (e.g. “Valid values for field Places on Risk”).
4.	Increased font size of field names in graph to make them more prominent. The field names actually make up for the information lost since they indicate the class of the target node (e.g. field name Places pointing to USAddress of type Place). 
5.	Removed rpm.class and rpm.enum prefixes from the displayed class names on nodes, in info panel and on error messages.
