### PR TITLE
Visualizer: Change group buttons to pick up graph colors + make network physics parms available

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -41,6 +41,8 @@ class VisualizerRelInfo
 	{
 		Map node = options.node as Map
 		targetCube = NCubeManager.getCube(appId, node.cubeName as String)
+		String sourceCubeName = node.sourceCubeName as String
+		sourceCube = sourceCubeName ? NCubeManager.getCube(appId, sourceCubeName) : null
 		sourceFieldName = node.fromFieldName
 		targetId = Long.valueOf(node.id as String)
 		targetLevel = Long.valueOf(node.level as String)
@@ -342,6 +344,7 @@ class VisualizerRelInfo
 		node.id = String.valueOf(targetId)
 		node.level = String.valueOf(targetLevel)
 		node.cubeName = targetCubeName
+		node.sourceCubeName = sourceCube ? sourceCube.name : null
 		node.scope = targetScope
 		node.availableScope = scope
 		node.fromFieldName = sourceFieldName == null ? null : sourceFieldName

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -70,3 +70,16 @@ ul, li{
 h3{
     margin-top: 0px;
 }
+
+.btn-primary-group {
+}
+
+.btn-default-group {
+}
+
+#networkPhysics-parms
+{
+    display:none;
+    visibility:inherit;
+    background-color:#d2d8c9;
+}

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -76,7 +76,6 @@
                         <div id="groups-div" class="inline-block" title="Show/hide group in the graph">
                             <div>
                                 <div id="groups" class="btn-group btn-group-sm" data-toggle="buttons">Loading groups... </div>
-
                                 <div class="select-all pull-right">
                                     &nbsp;&nbsp;<a id="selectAll" href="#">all</a>&nbsp;&nbsp;<a id="selectNone" href="#">none</a>
                                 </div>
@@ -84,10 +83,13 @@
 
                         </div>
                     </div>
+                </div>
 
-                <!--  Network physics parameters
+                <div id="visualizer-network">
+                    <div id="network">Loading network...</div>
+                </div>
 
-                <div id="network-parms">
+                <div id="networkPhysics-parms">
 
                     <div class="inline-block">
                         <label>Network Physics: </label>
@@ -115,7 +117,7 @@
                     </div>
 
                     <div class="inline-block">
-                       iterations:
+                        iterations:
                     </div>
                     <div id="iterations-div" class="inline-block">
                         <div class="input-group input-group-sm">
@@ -124,7 +126,7 @@
                     </div>
 
                     <div class="inline-block">
-                       damping:
+                        damping:
                     </div>
                     <div id="damping-div" class="inline-block">
                         <div class="input-group input-group-sm">
@@ -133,7 +135,7 @@
                     </div>
 
                     <div class="inline-block">
-                       minVelocity:
+                        minVelocity:
                     </div>
                     <div id="minVelocity-div" class="inline-block">
                         <div class="input-group input-group-sm">
@@ -142,7 +144,7 @@
                     </div>
 
                     <div class="inline-block">
-                       maxVelocity:
+                        maxVelocity:
                     </div>
                     <div id="maxVelocity-div" class="inline-block">
                         <div class="input-group input-group-sm">
@@ -151,7 +153,7 @@
                     </div>
 
                     <div class="inline-block">
-                       gravitationalConstant:
+                        gravitationalConstant:
                     </div>
                     <div id="gravitationalConstant-div" class="inline-block">
                         <div class="input-group input-group-sm">
@@ -159,18 +161,6 @@
                         </div>
                     </div>
 
-                    <div id="refresh-div" class="inline-block">
-                        <div class="input-group input-group-sm" title="Refresh view of graph for included/excluded groups">
-                            <button id="refresh" class="btn btn-primary btn-xs">Refresh</button>
-                        </div>
-                    </div>
-
-                </div>
-                -->
-                </div>
-
-                <div id="visualizer-network">
-                    <div id="network">Loading network...</div>
                 </div>
 
             </div>


### PR DESCRIPTION
1.	Fix bug that caused null pointer when loading traits on enums.
2.	Change group buttons to pick up the color specified for their corresponding network shapes.
3.	Make network physics parms available for display. To get them to display, put a breakpoint in the Chrome console after “_networkPhysicsParms.hide();”, then execute “_networkPhysicsParms.show();” in the console.