### PR TITLE
Visualizer: Added start cube validation and changed info panel

### DIFF
--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -256,11 +256,6 @@ class NCubeController extends BaseController
     // TODO: This needs to be externalized (loaded via Grapes)
     Map<String, Object> getVisualizerJson(ApplicationID appId, Map options)
     {
-        String cubeName = options.startCubeName as String
-        if (!cubeName.startsWith(VisualizerConstants.RPM_CLASS))
-        {
-            throw new IllegalArgumentException("Starting cube for visualization must begin with 'rpm.class', n-cube: ${cubeName} does not.")
-        }
         appId = addTenant(appId)
         Visualizer vis = new Visualizer()
         return vis.buildGraph(appId, options)

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -47,6 +47,11 @@ class Visualizer
 
 		VisualizerInfo visInfo = new VisualizerInfo(appId, options)
 
+		if (!isValidStartCube(visInfo.startCubeName))
+		{
+			return [status: STATUS_INVALID_START_CUBE, visInfo: visInfo, message: messages.join(DOUBLE_BREAK)]
+		}
+
 		if (hasMissingMinimumScope(visInfo))
 		{
 			return [status: STATUS_MISSING_START_SCOPE, visInfo: visInfo, message: messages.join(DOUBLE_BREAK)]
@@ -355,6 +360,23 @@ class Visualizer
 		}
 		scope[EFFECTIVE_VERSION] = defaultScopeEffectiveVersion
 		return scope
+	}
+
+	private boolean isValidStartCube(String cubeName)
+	{
+		if (!cubeName.startsWith(RPM_CLASS_DOT))
+		{
+			messages << "Starting cube for visualization must begin with 'rpm.class', n-cube ${cubeName} does not.".toString()
+			return false
+		}
+
+		NCube cube = NCubeManager.getCube(appId, cubeName)
+		if (!cube.getAxis(AXIS_FIELD) || !cube.getAxis(AXIS_TRAIT) )
+		{
+			messages << "Cube ${cubeName} is not a valid rpm class since it does not have both a field axis and a traits axis.".toString()
+			return false
+		}
+		return true
 	}
 
 	private boolean hasMissingMinimumScope(VisualizerInfo visInfo)

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -69,6 +69,7 @@ public final class VisualizerConstants
 
 	public static final String STATUS_MISSING_START_SCOPE = 'missingStartScope'
 	public static final String STATUS_SUCCESS = 'success'
+	public static final String STATUS_INVALID_START_CUBE = 'invalidStartCube'
 	public static final SafeSimpleDateFormat DATE_TIME_FORMAT = new SafeSimpleDateFormat('yyyy-MM-dd')
 
 	public static final String HTTP = 'http:'

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -239,14 +239,8 @@ class VisualizerRelInfo
 	{
 		if (sourceCube.getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
 		{
-			if (sourceTraitMaps[CLASS_TRAITS][R_SCOPED_NAME] == null)
-			{
-				return null
-			}
-			else
-			{
-				return RPM_CLASS_DOT + sourceFieldRpmType
-			}
+			String scopedName = sourceTraitMaps[CLASS_TRAITS][R_SCOPED_NAME]
+			return !scopedName ?: RPM_CLASS_DOT + sourceFieldRpmType
 		}
 		return RPM_CLASS_DOT + targetFieldName
 	}
@@ -360,13 +354,12 @@ class VisualizerRelInfo
 		if (targetCubeName.startsWith(RPM_CLASS_DOT))
 		{
 			node.label = getDotSuffix(targetEffectiveName)
-			String cubeDisplayName = getCubeDisplayName(targetCubeName)
-			node.detailsTitle = cubeDisplayName
-			node.title = cubeDisplayName
+			node.detailsTitle = getCubeDetailsTitle(targetCubeName)
+			node.title = getCubeDisplayName(targetCubeName)
 		}
 		else
 		{
-			String detailsTitle = "Valid values for field ${sourceFieldName} on ${getCubeDisplayName(sourceCube.name)}".toString()
+			String detailsTitle = getCubeDetailsTitle(targetCubeName)
 			node.detailsTitle = detailsTitle
 			node.title = detailsTitle
 		}
@@ -395,10 +388,28 @@ class VisualizerRelInfo
 		{
 			displayName = cubeName - RPM_ENUM_DOT
 		}
-	    else
-		{
-			throw new IllegalArgumentException("Cube name is expected to start with one of the following: ${RPM_CLASS_DOT}, ${RPM_ENUM_DOT}.")
-		}
 		return displayName
+	}
+
+	String getCubeDetailsTitle(String cubeName)
+	{
+		String detailsTitle
+		if (cubeName.startsWith(RPM_CLASS_DOT))
+		{
+			String targetScopedName = getTargetScopedName()
+			if (targetScopedName)
+			{
+				detailsTitle = "${getCubeDisplayName(cubeName)} ${getEffectiveNameByCubeName()}"
+			}
+			else
+			{
+				detailsTitle = getCubeDisplayName(cubeName)
+			}
+		}
+		else if (cubeName.startsWith(RPM_ENUM_DOT))
+		{
+			detailsTitle = "Valid values for field ${sourceFieldName} on ${getCubeDisplayName(sourceCube.name)}".toString()
+		}
+		return detailsTitle
 	}
 }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -1094,7 +1094,7 @@ var Visualizer = (function ($) {
     {
         var cubeLink = $('<a/>');
         cubeLink.addClass('nc-anc');
-        cubeLink.html('View ' + cubeName);
+        cubeLink.html('Open n-cube');
         cubeLink.click(function (e) {
             e.preventDefault();
             _nce.selectCubeByName(cubeName, appId, TAB_VIEW_TYPE_NCUBE + PAGE_ID);


### PR DESCRIPTION
1.	Added validation that cube starts with rpm.class (removed same edit from NCubeController). Also validating that start cube has at least a field and a trait axis. This is in fact the minimum require by Dynamis to load a cube as an rpm.class.
2.	Changed info panel title to show class type and scope name for EPM classes (e.g. Product WorkersCompensationProduct). For non-EPM classes it shows the full cube name minus rpm.class or minus rpm.enum (e.g. account.CustomerSecurityAgreement).
3.	Changed link to cube in info panel to say “Open n-cube”.