### PR TITLE
Visualizer: Display all network options for edit dynamically, change minVelocity parm, remove clustering feature and more

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -325,14 +325,20 @@ class VisualizerRelInfo
 		edge.toName = targetCubeEffectiveName
 		edge.fromFieldName = sourceFieldName
 		edge.level = String.valueOf(targetLevel)
-		if (targetCube.name.startsWith(RPM_ENUM_DOT))
-		{
-			edge.label = sourceFieldName
-		}
 		Map<String, Map<String, Object>> sourceFieldTraitMap = sourceTraitMaps[sourceFieldName] as Map
 		String vMin = sourceFieldTraitMap[V_MIN] as String ?: '0'
 		String vMax = sourceFieldTraitMap[V_MAX] as String ?: '999999'
-		edge.title = "Field ${sourceFieldName} with min:max cardinality of ${vMin}:${vMax}".toString()
+
+		if (targetCube.name.startsWith(RPM_ENUM_DOT))
+		{
+			edge.label = sourceFieldName
+			edge.title = "Field ${sourceFieldName} with min:max cardinality of ${vMin}:${vMax}".toString()
+		}
+		else
+		{
+			edge.title = "Valid value ${sourceFieldName} with min:max cardinality of ${vMin}:${vMax}".toString()
+		}
+
 		return edge
 	}
 

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -107,3 +107,7 @@ h3{
 .highlighted{
     background-color:#FFFF00;
 }
+
+.readOnly{
+    background-color:rgb(235, 235, 228);
+}

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -103,3 +103,7 @@ h3{
 .borders div{
 
 }
+
+.highlighted{
+    background-color:#FFFF00;
+}

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -77,7 +77,7 @@ h3{
 .btn-default-group {
 }
 
-#networkOptionsDisplay
+#networkOptionsButton
 {
     background-image: url('../img/einstein.png');
     cursor:pointer;
@@ -88,12 +88,12 @@ h3{
     box-shadow: inset 0 6px 14px rgba(0,0,0,.70);
 }
 
-#networkOptionsDisplay.active {
+#networkOptionsButton.active {
     box-shadow: none;
     border: none;
 }
 
-#networkPhysics-parms
+#networkOptionsSection
 {
     display:none;
     visibility:inherit;

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -100,7 +100,7 @@
 
                     <div class="row">
                         <div class="col-md-3"><h3><img src="./img/einstein.png"/>&nbsp;&nbsp;<b>Network Options</b></h3></div>
-                        <div class="col-md-9"><a href="http://visjs.org/docs/network/" target="_blank">http://visjs.org/docs/network/physics.html </a></div>
+                        <div class="col-md-9"><a href="http://visjs.org/docs/network/" target="_blank">http://visjs.org/docs/network/ </a></div>
                     </div>
 
                     <div class="row">

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -123,7 +123,7 @@
                         <div class="col-md-1"><b>Value</b></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><b>Default</b></div>
-                       <div class="col-md-5"><b>Visjs default, if different</b></div>
+                       <div class="col-md-5"><b>Vis default, if different</b></div>
                     </div>
 
                     <div id="networkOptionsChangeSection"></div>

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -108,10 +108,10 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-md-3"><b>Network status:</b></div>
+                        <div class="col-md-4"><b>Network status:</b></div>
                         <div class="col-md-1"><input id="stabilizationStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
-                        <div class="col-md-7"><input id="iterationsToStabilize" type="text" disabled="true"></div>
+                        <div class="col-md-6"><input id="iterationsToStabilize" type="text" disabled="true"></div>
                     </div>
 
                     <div class="row">
@@ -119,11 +119,11 @@
                      </div>
 
                     <div class="row borders">
-                        <div class="col-md-3"><b>Parameter</b></div>
+                        <div class="col-md-4"><b>Parameter</b></div>
                         <div class="col-md-1"><b>Value</b></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><b>Default</b></div>
-                       <div class="col-md-5"><b>Vis default, if different</b></div>
+                       <div class="col-md-4"><b>Vis default, if different</b></div>
                     </div>
 
                     <div id="networkOptionsChangeSection"></div>

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -70,8 +70,8 @@
                     </div>
 
                     <div id="networkOptions-div" class="inline-block">
-                        <div class="input-group input-group-sm" title="Display network physics options">
-                            <button id="networkOptionsDisplay" class="btn btn-sm"></button>
+                        <div class="input-group input-group-sm" title="Display network options">
+                            <button id="networkOptionsButton" class="btn btn-sm"></button>
                         </div>
                     </div>
 
@@ -92,15 +92,15 @@
                     <div id="network">Loading network...</div>
                 </div>
 
-                <div id="networkPhysics-parms">
+                <div id="networkOptionsSection">
 
                     <div class="row">
                         <div class="col-md-12">&nbsp;</div>
                     </div>
 
                     <div class="row">
-                        <div class="col-md-3"><h3><img src="./img/einstein.png"/>&nbsp;&nbsp;<b>Network Physics</b></h3></div>
-                        <div class="col-md-9"><a href="http://visjs.org/docs/network/physics.html" target="_blank">http://visjs.org/docs/network/physics.html </a></div>
+                        <div class="col-md-3"><h3><img src="./img/einstein.png"/>&nbsp;&nbsp;<b>Network Options</b></h3></div>
+                        <div class="col-md-9"><a href="http://visjs.org/docs/network/" target="_blank">http://visjs.org/docs/network/physics.html </a></div>
                     </div>
 
                     <div class="row">
@@ -121,348 +121,13 @@
                     <div class="row borders">
                         <div class="col-md-3"><b>Parameter</b></div>
                         <div class="col-md-1"><b>Value</b></div>
-                       <div class="col-md-1"></div>
+                        <div class="col-md-1"></div>
                         <div class="col-md-2"><b>Default</b></div>
                        <div class="col-md-5"><b>Visjs default, if different</b></div>
                     </div>
 
-                    <div class="row borders">
-                        <div class="col-md-3">physicsEnabled</div>
-                        <div class="col-md-1">
-                            <input id="physicsEnabled" type="checkbox">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="physicsEnabledDefault" type="checkbox" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_gravitationalConstant</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_gravitationalConstant" type="text">
-                        </div>
-                        <div class="col-md-1"></div>
-                        <div class="col-md-2">
-                            <input id="barnesHut_gravitationalConstantDefault" type="text" disabled="true">
-                        </div>
-                        <div class="col-md-5">-2000</div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_centralGravity</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_centralGravity" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_centralGravityDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_springLength</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_springLength" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_springLengthDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_springConstant</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_springConstant" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_springConstantDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_damping</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_damping" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_dampingDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">barnesHut_avoidOverlap</div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_avoidOverlap" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="barnesHut_avoidOverlapDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">repulsion_nodeDistance</div>
-                        <div class="col-md-1">
-                            <input id="repulsion_nodeDistance" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="repulsion_nodeDistanceDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">repulsion_centralGravity</div>
-                        <div class="col-md-1">
-                            <input id="repulsion_centralGravity" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="repulsion_centralGravityDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">repulsion_springLength</div>
-                        <div class="col-md-1">
-                            <input id="repulsion_springLength" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="repulsion_springLengthDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">repulsion_springConstant</div>
-                        <div class="col-md-1">
-                            <input id="repulsion_springConstant" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="repulsion_springConstantDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">repulsion_damping</div>
-                        <div class="col-md-1">
-                            <input id="repulsion_damping" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="repulsion_dampingDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">hierarchicalRepulsion_nodeDistance</div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_nodeDistance" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_nodeDistanceDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">hierarchicalRepulsion_centralGravity</div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_centralGravity" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_centralGravityDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">hierarchicalRepulsion_springLength</div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_springLength" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_springLengthDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">hierarchicalRepulsion_springConstant</div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_springConstant" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_springConstantDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">hierarchicalRepulsion_damping</div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_damping" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="hierarchicalRepulsion_dampingDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">maxVelocity</div>
-                        <div class="col-md-1">
-                            <input id="maxVelocity" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="maxVelocityDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">minVelocity</div>
-                        <div class="col-md-1">
-                            <input id="minVelocity" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="minVelocityDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">solver</div>
-                        <div class="col-md-1">
-                            <input id="solver" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="solverDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">stabilization_enabled</div>
-                        <div class="col-md-1">
-                            <input id="stabilization_enabled" type="checkbox">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="stabilization_enabledDefault" type="checkbox" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">stabilization_iterations</div>
-                        <div class="col-md-1">
-                            <input id="stabilization_iterations" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="stabilization_iterationsDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">stabilization_updateInterval</div>
-                        <div class="col-md-1">
-                            <input id="stabilization_updateInterval" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="stabilization_updateIntervalDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">stabilization_onlyDynamicEdges</div>
-                        <div class="col-md-1">
-                            <input id="stabilization_onlyDynamicEdges" type="checkbox">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="stabilization_onlyDynamicEdgesDefault" type="checkbox" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">stabilization_fit</div>
-                        <div class="col-md-1">
-                            <input id="stabilization_fit" type="checkbox">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="stabilization_fitDefault" type="checkbox" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">timestep</div>
-                        <div class="col-md-1">
-                            <input id="timestep" type="text">
-                        </div>
-                       <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="timestepDefault" type="text" disabled="true">
-                        </div>
-                       <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">adaptiveTimestep</div>
-                        <div class="col-md-1">
-                            <input id="adaptiveTimestep" type="checkbox">
-                        </div>
-                        <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="adaptiveTimestepDefault" type="checkbox" disabled="true">
-                        </div>
-                        <div class="col-md-6"></div>
-                    </div>
-
-                    <div class="row borders">
-                        <div class="col-md-3">improvedLayout</div>
-                        <div class="col-md-1">
-                            <input id="improvedLayout" type="checkbox">
-                        </div>
-                        <div class="col-md-1"></div>
-                        <div class="col-md-1">
-                            <input id="improvedLayoutDefault" type="checkbox" disabled="true">
-                        </div>
-                        <div class="col-md-6"></div>
-                    </div>
-
-                </div>
+                    <div id="networkOptionsChangeSection"></div>
+                 </div>
             </div>
        </div>
     </div>

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -97,6 +97,7 @@ var CLASS_SECTION_NONE = 'section-none';
 
 var OBJECT = 'object';
 var BOOLEAN = 'boolean';
+var NUMBER = 'number';
 
 var GLYPHICONS = {
     OPTION_HORIZONTAL: 'glyphicon-option-horizontal',

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -96,6 +96,7 @@ var CLASS_SECTION_ALL = 'section-all';
 var CLASS_SECTION_NONE = 'section-none';
 
 var OBJECT = 'object';
+var BOOLEAN = 'boolean';
 
 var GLYPHICONS = {
     OPTION_HORIZONTAL: 'glyphicon-option-horizontal',

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -98,6 +98,7 @@ var CLASS_SECTION_NONE = 'section-none';
 var OBJECT = 'object';
 var BOOLEAN = 'boolean';
 var NUMBER = 'number';
+var FUNCTION = 'function';
 
 var GLYPHICONS = {
     OPTION_HORIZONTAL: 'glyphicon-option-horizontal',

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -67,23 +67,216 @@ var Visualizer = (function ($) {
     var _clickTimer = null;
     var _clicks = 0;
 
+    //Network layout parameters
+    var _hierarchical = false;
 
     //Network physics
     var _networkOptionsButton = null;
     var _networkOptionsSection = null;
     var _networkOptionsChangeSection = null;
-    var _physicsDefaultsVis = null;
-    var _physicsDefaults = null;
-    var _physicsParms = null;
-    var _overriddenPhysicsOptions =
+    var _networkDefaultsVis = {};
+    var _networkDefaults = null;
+    var _networkOptions = null;
+    var _overriddenNetworkOptions =
     {
-        barnesHut: {
-            gravitationalConstant: -30000
+        height: getVisNetworkHeight(),
+        interaction: {
+            navigationButtons: true,
+            keyboard: {
+                enabled: false,
+                speed: {x: 5, y: 5, zoom: 0.02}
+            },
+            zoomView: true
+        },
+        nodes: {
+            value: 24,
+            scaling: {
+                min: 24,
+                max: 24,
+                label: {
+                    enabled: true
+                }
+            }
+        },
+        edges: {
+            arrows: {
+                to: {
+                    enabled: true
+                }
+            },
+            color: {
+                color: 'gray'
+            },
+            smooth: {
+                enabled: true
+            },
+            hoverWidth: 3,
+            font: {
+                size: 20
+            }
+        },
+        physics: {
+            barnesHut: {
+                gravitationalConstant: -30000
+            }
+        },
+        layout: {
+            hierarchical: {
+                enabled: _hierarchical
+            },
+            improvedLayout : true,
+            randomSeed:2
+        },
+        groups: {
+            PRODUCT: {
+                shape: 'box',
+                color: '#DAE4FA'
+            },
+            RISK: {
+                shape: 'box',
+                color: '#759BEC'
+            },
+            COVERAGE: {
+                shape: 'box',
+                color: '#113275',
+                font: {
+                    color: '#D8D8D8'
+                }
+            },
+            CONTAINER: {
+                shape: 'star',
+                color: "#731d1d",
+                font: {
+                    buttonColor: '#D8D8D8'
+                }
+            },
+            LIMIT: {
+                shape: 'ellipse',
+                color: '#FFFF99'
+            },
+            DEDUCTIBLE: {
+                shape: 'ellipse',
+                color: '#FFFF99'
+            },
+            PREMIUM: {
+                shape: 'ellipse',
+                color: '#0B930B',
+                font: {
+                    color: '#D8D8D8'
+                }
+            },
+            RATE: {
+                shape: 'ellipse',
+                color: '#EAC259'
+            },
+            ROLE: {
+                shape: 'box',
+                color: '#F59D56'
+            },
+            ROLEPLAYER: {
+                shape: 'box',
+                color: '#F2F2F2'
+            },
+            RATEFACTOR: {
+                shape: 'ellipse',
+                color: '#EAC259'
+            },
+            PARTY: {
+                shape: 'box',
+                color: '#004000',
+                font: {
+                    color: '#D8D8D8'
+                }
+            },
+            PLACE: {
+                shape: 'box',
+                color: '#481849',
+                font: {
+                    color: '#D8D8D8'
+                }
+            },
+            UNSPECIFIED: {
+                shape: 'box',
+                color: '#7ac5cd'
+            },
+            FORM: {
+                shape: 'box',
+                color: '#d2691e'
+            },
+            PRODUCT_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            RISK_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            COVERAGE_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            LIMIT_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            PREMIUM_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            RATE_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            RATEFACTOR_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            ROLE_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            ROLEPLAYER_ENUM : {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            CONTAINER_ENUM: {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            DEDUCTIBLE_ENUM: {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            PARTY_ENUM: {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            PLACE_ENUM: {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            },
+            UNSPECIFIED_ENUM: {
+                shape: 'dot',
+                scaling: {min: 5, max: 5},
+                color: 'gray'
+            }
         }
-    }
+    };
 
-    //Network layout parameters
-    var _hierarchical = false;
+
 
     //Set by network stabilize events
     var _stabilizationStatus = null;
@@ -147,11 +340,11 @@ var Visualizer = (function ($) {
                 //if hierarchical mode is selected since that mode requires either all or no nodes to
                 //have a defined level. Attempted short-term fix in setLevelOnNetworkNodes() method, but it's not enough.
                 //TODO: Keep investigating, submit question and possibly a bug fix to visjs.
-                $('#hierarchical').prop('checked', false);
-                _nce.showNote('Hierarchical mode is currently not available');
-                //_hierarchical = this.checked;
-                //saveToLocalStorage(_hierarchical, HIERARCHICAL);
-                //updateNetworkOptions();
+               // $('#hierarchical').prop('checked', false);
+               // _nce.showNote('Hierarchical mode is currently not available');
+                _hierarchical = this.checked;
+                saveToLocalStorage(_hierarchical, HIERARCHICAL);
+                updateNetworkOptions();
             });
 
             _scopeInput.on('change', function () {
@@ -177,45 +370,55 @@ var Visualizer = (function ($) {
                 _networkOptionsSection.toggle();
             });
 
-            $('#networkOptionsChangeSection').change(function () {
+            $('#networkOptionsChangeSection').change(function ()
+            {
                 _networkOptionsChangeSection = $('#networkOptionsChangeSection');
                 $('.networkOption').each(function(){
-                    setNetworkOptions($(this),_physicsParms)
+                    var id, keys;
+                    id = $(this).attr('id');
+                    keys = id.split('.');
+                    setNetworkOption($(this), _networkOptions, keys);
                 });
-
                 destroyNetwork();
                 initNetwork();
             });
         }
     };
 
-
-    function setNetworkOptions(element, options)
+    function setNetworkOption(inputOption, options, keys)
     {
-        var id, fullKey, partKey, optionValue, value;
-        id = element.attr('id');
-        fullKey = id.split('.');
-        optionValue = options[fullKey[1]];
-        for (var i = 2, iLen = fullKey.length; i < iLen; i++)//TODO: change to 0 when all options
-        {
-            partKey = fullKey[i];
-            value = optionValue[partKey];
-            if(typeof value === OBJECT)
+        var key, value, errorMessage;
+        if (keys) {
+            key = keys[0];
+            value = options[key];
+            if (typeof value === OBJECT)
             {
-                optionValue = value;
+                keys.splice(key, 1);
+                setNetworkOption(inputOption, value, keys)
             }
             else if (typeof value === BOOLEAN)
             {
-                optionValue[partKey] =  element.prop('checked');
+                options[key] = inputOption.prop('checked');
             }
             else if (typeof value === NUMBER)
             {
-                optionValue[partKey] = Number(element.val());
+                options[key] = Number(inputOption.val());
+            }
+            else if (typeof value === 'function')
+            {
+                //TODO: add this back in 
+                //options[key] = Function(inputOption.val());
             }
             else
             {
-                optionValue[partKey] = element.val();
+                options[key] = inputOption.val();
             }
+        }
+        else
+        {
+            errorMessage = 'Invalid state encountered while updating network options for parameter ' + inputOption.attr('id') + '.';
+            _nce.showNote(errorMessage);
+            throw new Error(errorMessage);
         }
     }
 
@@ -225,13 +428,25 @@ var Visualizer = (function ($) {
         container = document.getElementById('network');
         emptyDataSet = new vis.DataSet({});
         emptyNetwork = new vis.Network(container, {nodes:emptyDataSet, edges:emptyDataSet}, {});
-        _physicsDefaultsVis = emptyNetwork.physics.defaultOptions;
-        delete _physicsDefaultsVis.barnesHut['theta'];  //TODO: Figure out why key throws "unknown" exception in visjs when set on the network. Removing for now.
-        delete _physicsDefaultsVis.forceAtlas2Based['theta'];  //TODO: Figure out why key throws "unknown" exception in visjs when set on the network. Removing for now.
-        delete _physicsDefaultsVis.repulsion['avoidOverlap'];  //TODO: Figure out why key throws "unknown" exception in visjs when set on the network. Removing for now.
+
+        _networkDefaultsVis.physics = emptyNetwork.physics.defaultOptions;
+        _networkDefaultsVis.physics = emptyNetwork.physics.defaultOptions;
+        _networkDefaultsVis.layout = emptyNetwork.layoutEngine.defaultOptions;
+        _networkDefaultsVis.nodes = emptyNetwork.nodesHandler.defaultOptions;
+        _networkDefaultsVis.edges = emptyNetwork.edgesHandler.defaultOptions;
+        _networkDefaultsVis.groups = emptyNetwork.groups.defaultOptions;
+        _networkDefaultsVis.interaction = emptyNetwork.interactionHandler.defaultOptions;
+        _networkDefaultsVis.manipulation = emptyNetwork.manipulation.defaultOptions;
+
+        //TODO: Figure out why key throws "unknown" exception in visjs when set on the network. Removing for now.
+        delete _networkDefaultsVis.physics.barnesHut['theta'];  
+        delete _networkDefaultsVis.physics.forceAtlas2Based['theta'];  
+        delete _networkDefaultsVis.physics.repulsion['avoidOverlap'];
+
+        _networkDefaults = $.extend(true, {}, _networkDefaultsVis);
+        _networkOptions = $.extend(true, _networkDefaults, _overriddenNetworkOptions);
+
         emptyNetwork.destroy();
-        _physicsDefaults = $.extend(true, {}, _physicsDefaultsVis);
-        _physicsParms = $.extend(true, _physicsDefaults, _overriddenPhysicsOptions);
     }
 
     function loadNetworkOptionsSectionView()
@@ -252,25 +467,35 @@ var Visualizer = (function ($) {
         $("#iterationsToStabilize").val(_iterationsToStabilize);
 
         $('#networkOptionsChangeSection').empty();
-        buildNetworkOptionsChangeSection( $('#networkOptionsChangeSection'), 'physics', _physicsParms, _physicsDefaults, _physicsDefaultsVis);
+        buildNetworkOptionsChangeSection( $('#networkOptionsChangeSection'), null, _networkOptions, _networkDefaults, _networkDefaultsVis);
     }
 
-    function buildNetworkOptionsChangeSection(section, parentKey, options, defaultOptions, visDefaultOptions)
+    function buildNetworkOptionsChangeSection(section, parentKey, networkOptions, networkDefaults, networkDefaultsVis)
     {
-        $.each(defaultOptions, function (key, defaultValue) {
-            var rowBordersDiv, value, defaultValueVis;
-            value = options[key];
-            defaultValueVis = visDefaultOptions[key];
-            rowBordersDiv = buildRowBordersDiv(section, parentKey, key, value, defaultValue, defaultValueVis);
+        $.each(networkDefaults, function (key, defaultValue) {
+            var rowBordersDiv, value, defaultKeyVis, defaultValueVis;
+            value = networkOptions[key];
+            if (networkDefaultsVis)
+            {
+                defaultKeyVis =  key in networkDefaultsVis ? key : null;
+                defaultValueVis = networkDefaultsVis[key];
+            }
+            else
+            {
+                defaultKeyVis = null;
+                defaultValueVis = null;
+            }
+
+            rowBordersDiv = buildRowBordersDiv(section, parentKey, key, value, defaultValue, defaultKeyVis, defaultValueVis);
             section.append(rowBordersDiv);
         });
     }
 
-    function buildRowBordersDiv(section, parentKey, key, value, defaultValue, defaultValueVis)
+    function buildRowBordersDiv(section, parentKey, key, value, defaultValue, defaultKeyVis, defaultValueVis)
     {
-        var rowBordersDiv, col1Div, col2Div, col3Div, col4Div, col5Div, col2Input, col4Input, fullKey;
+        var rowBordersDiv, col1Div, col2Div, col3Div, col4Div, col5Div, col2Input, col4Input, col5Input, fullKey, differentVisDefaultValue;
 
-        fullKey = parentKey + '.' + key;
+        fullKey = parentKey === null ? key : parentKey + '.' + key;
 
         rowBordersDiv = $('<div/>').prop({class: "row borders"});
         col1Div = $('<div/>').prop({class: "col-md-3"});
@@ -288,22 +513,38 @@ var Visualizer = (function ($) {
             if (typeof defaultValue === BOOLEAN) {
                 col2Input = $('<input/>').prop({class: 'networkOption', id: fullKey, type: "checkbox"});
                 col2Input[0].checked = value;
-                col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "checkbox", readOnly: "true"});
+                col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "checkbox", disabled: "true"});
                 col4Input[0].checked = defaultValue;
             }
             else {
                 col2Input = $('<input/>').prop({class: 'networkOption', id: fullKey, type: "text"});
                 col2Input[0].value = value;
-                col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "text", readOnly: "true"});
+                col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "text", disabled: "true"});
                 col4Input[0].value = defaultValue;
             }
-
-
+            
             col1Div[0].innerHTML = fullKey
             col2Div.append(col2Input);
             col3Div[0].innerHTML = NBSP;
             col4Div.append(col4Input);
-            col5Div[0].innerHTML = defaultValueVis === defaultValue ? null : defaultValueVis;
+
+            if (defaultKeyVis)
+            {
+                differentVisDefaultValue = defaultValueVis === defaultValue ? null : defaultValueVis;
+                if (typeof differentVisDefaultValue === BOOLEAN) {
+                    col5Input = $('<input/>').prop({class: 'networkOption', id: fullKey, type: "checkbox", disabled: "true"});
+                    col5Input[0].checked = differentVisDefaultValue;
+                    }
+                else  if (differentVisDefaultValue !== null)
+                {
+                    col5Input = $('<input/>').prop({class: 'networkOption', id: fullKey, type: "text", disabled: "true"});
+                    col5Input[0].value = differentVisDefaultValue;
+                 }
+                col5Div.append(col5Input);
+            }
+            else {
+                col5Div[0].innerHTML = 'Parameter does not exist in Vis'
+            }
 
             rowBordersDiv.append(col1Div);
             rowBordersDiv.append(col2Div);
@@ -600,7 +841,7 @@ var Visualizer = (function ($) {
         var divGroups = $('#groups');
 
         divGroups.empty();
-        groups = getNetworkOptions().groups;
+        groups = _networkOptions.groups;
 
         _availableGroupsAllLevels.sort();
         for (var j = 0; j < _availableGroupsAllLevels.length; j++) {
@@ -1023,7 +1264,7 @@ var Visualizer = (function ($) {
             nodeDataSet.add(_nodes)
             edgeDataSet = new vis.DataSet({});
              edgeDataSet.add(_edges)
-            _network = new vis.Network(container, {nodes:nodeDataSet, edges:edgeDataSet}, getNetworkOptions());
+            _network = new vis.Network(container, {nodes:nodeDataSet, edges:edgeDataSet}, _networkOptions);
             updateNetworkData();
             customizeNetworkForNce(_network);
 
@@ -1123,7 +1364,7 @@ var Visualizer = (function ($) {
 
      function updateNetworkOptions()
     {
-        _network.setOptions(getNetworkOptions());
+        _network.setOptions(_networkOptions);
     }
 
     function createVisualizeFromHereLink(appId, cubeName, node)
@@ -1288,200 +1529,6 @@ var Visualizer = (function ($) {
             return this.clustering.clusterDescendants.apply(this.clustering, arguments);
         };
     }
-    
-    function getNetworkOptions()
-    {
-        var options =
-        {
-            height: getVisNetworkHeight(),
-            interaction: {
-                navigationButtons: true,
-                keyboard: {
-                    enabled: false,
-                    speed: {x: 5, y: 5, zoom: 0.02}
-                },
-                zoomView: true
-            },
-            nodes: {
-                value: 24,
-                scaling: {
-                    min: 24,
-                    max: 24,
-                    label: {
-                        enabled: true
-                    }
-                }
-            },
-            edges: {
-                arrows: 'to',
-                color: 'gray',
-                smooth: true,
-                hoverWidth: 3,
-                font: {
-                    size: 20
-                }
-            },
-            physics: {
-                //Merged in from _physicsParms, below
-             },
-            layout: {
-                hierarchical: _hierarchical,
-                improvedLayout : true,
-                randomSeed:2
-            },
-            groups: {
-                PRODUCT: {
-                    shape: 'box',
-                    color: '#DAE4FA'
-                },
-                RISK: {
-                    shape: 'box',
-                    color: '#759BEC'
-                },
-                COVERAGE: {
-                    shape: 'box',
-                    color: '#113275',
-                    font: {
-                        color: '#D8D8D8'
-                    }
-                },
-                CONTAINER: {
-                    shape: 'star',
-                    color: "#731d1d",
-                    font: {
-                        buttonColor: '#D8D8D8'
-                    }
-                },
-                LIMIT: {
-                    shape: 'ellipse',
-                    color: '#FFFF99'
-                },
-                DEDUCTIBLE: {
-                    shape: 'ellipse',
-                    color: '#FFFF99'
-                },
-                PREMIUM: {
-                    shape: 'ellipse',
-                    color: '#0B930B',
-                    font: {
-                        color: '#D8D8D8'
-                    }
-                },
-                RATE: {
-                    shape: 'ellipse',
-                    color: '#EAC259'
-                },
-                ROLE: {
-                    shape: 'box',
-                    color: '#F59D56'
-                },
-                ROLEPLAYER: {
-                    shape: 'box',
-                    color: '#F2F2F2'
-                },
-                RATEFACTOR: {
-                    shape: 'ellipse',
-                    color: '#EAC259'
-                },
-                PARTY: {
-                    shape: 'box',
-                    color: '#004000',
-                    font: {
-                        color: '#D8D8D8'
-                    }
-                },
-                PLACE: {
-                    shape: 'box',
-                    color: '#481849',
-                    font: {
-                        color: '#D8D8D8'
-                    }
-                },
-                UNSPECIFIED: {
-                    shape: 'box',
-                    color: '#7ac5cd'
-                },
-                FORM: {
-                    shape: 'box',
-                    color: '#d2691e'
-                },
-                PRODUCT_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                RISK_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                COVERAGE_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                LIMIT_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                PREMIUM_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                RATE_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                RATEFACTOR_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                ROLE_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                ROLEPLAYER_ENUM : {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                CONTAINER_ENUM: {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                DEDUCTIBLE_ENUM: {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                PARTY_ENUM: {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                PLACE_ENUM: {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                },
-                UNSPECIFIED_ENUM: {
-                    shape: 'dot',
-                    scaling: {min: 5, max: 5},
-                    color: 'gray'   
-                }
-            }
-        };
-
-        $.extend(true, options.physics, _physicsParms);
-        return options;
-    }
-
 
     function getFromLocalStorage(key, defaultValue) {
         var local = localStorage[getStorageKey(_nce, key)];

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -77,6 +77,7 @@ var Visualizer = (function ($) {
     var DASH_LENGTH = 15;
     var EDGE_FONT = 20;
     var GRAVITATIONAL_CONSTANT = -30000;
+    var MIN_VELOCITY = 0.85;
     var _networkOptionsButton = null;
     var _networkOptionsSection = null;
     var _networkOptionsChangeSection = null;
@@ -125,6 +126,7 @@ var Visualizer = (function ($) {
             }
         },
         physics: {
+            minVelocity: MIN_VELOCITY,
             barnesHut: {
                 gravitationalConstant: GRAVITATIONAL_CONSTANT
             }
@@ -421,7 +423,7 @@ var Visualizer = (function ($) {
             }
             else if (FUNCTION === typeof value)
             {
-                options[key] = Function(inputOption.val());
+                //Not supporting updating of netork options that are functions.   
             }
             else
             {
@@ -487,7 +489,7 @@ var Visualizer = (function ($) {
     function buildNetworkOptionsChangeSection(section, parentKey, networkOptions, networkOptionsDefaults, networkOptionsVis)
     {
         var rowBordersDiv, col1Div, col2Div, col3Div, col4Div, col5Div, col2Input, col4Input, col5Input, fullKey,
-            value, keyVis, valueVis, highlighted;
+            value, keyVis, valueVis, highlightedClass, readOnly, readOnlyClass, functionTitle;
 
         $.each(networkOptionsDefaults, function (key, defaultValue)
         {
@@ -513,22 +515,25 @@ var Visualizer = (function ($) {
             {
                 rowBordersDiv = $('<div/>').prop({class: "row borders"});
                 col1Div = $('<div/>').prop({class: "col-md-3"});
-                col2Div = $('<div/>').prop({class: "col-md-1", title:"Value used for network"});
+                col2Div = $('<div/>').prop({class: "col-md-1"});
                 col3Div = $('<div/>').prop({class: "col-md-1"});
-                col4Div = $('<div/>').prop({class: "col-md-2", title:"Default value for network"});
-                col5Div = $('<div/>').prop({class: "col-md-5", title:"Vis default value, if different"});
+                col4Div = $('<div/>').prop({class: "col-md-2"});
+                col5Div = $('<div/>').prop({class: "col-md-5"});
 
-                highlighted = value === defaultValue ? '' : ' highlighted';
+                highlightedClass = value === defaultValue ? '' : ' highlighted';
                 if (typeof defaultValue === BOOLEAN) {
-                    col2Input = $('<input/>').prop({class: 'networkOption' + highlighted, id: fullKey, type: "checkbox"});
+                    col2Input = $('<input/>').prop({class: 'networkOption' + highlightedClass, id: fullKey, type: "checkbox"});
                     col2Input[0].checked = value;
-                    col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "checkbox", disabled: "true"});
+                    col4Input = $('<input/>').prop({class: 'readOnly', id: fullKey + 'Default', type: "checkbox", readOnly: "true"});
                     col4Input[0].checked = defaultValue;
                 }
                 else {
-                    col2Input = $('<input/>').prop({class: 'networkOption' + highlighted, id: fullKey, type: "text"});
+                    readOnly = FUNCTION === typeof value ? true: false;
+                    readOnlyClass = readOnly ? ' readOnly' : '';
+                    functionTitle = "Not currently supporting update of network options that are functions.";
+                    col2Input = $('<input/>').prop({class: 'networkOption' + highlightedClass + readOnlyClass, id: fullKey, type: "text", readOnly: readOnly, title: functionTitle});
                     col2Input[0].value = value;
-                    col4Input = $('<input/>').prop({id: fullKey + 'Default', type: "text", disabled: "true"});
+                    col4Input = $('<input/>').prop({class: 'readOnly', id: fullKey + 'Default', type: "text", readOnly: "true"});
                     col4Input[0].value = defaultValue;
                 }
                 col1Div[0].innerHTML = fullKey;
@@ -544,13 +549,13 @@ var Visualizer = (function ($) {
                     }
                     else if (BOOLEAN === typeof valueVis )
                     {
-                        col5Input = $('<input/>').prop({id: fullKey, type: "checkbox", disabled: "true"});
+                        col5Input = $('<input/>').prop({class: 'readOnly', id: fullKey, type: "checkbox", readOnly: "true"});
                         col5Input[0].checked = valueVis;
                         col5Div.append(col5Input);
                     }
                     else
                     {
-                        col5Input = $('<input/>').prop({id: fullKey, type: "text", disabled: "true"});
+                        col5Input = $('<input/>').prop({class: 'readOnly', id: fullKey, type: "text", readOnly: "true"});
                         col5Input[0].value = valueVis;
                         col5Div.append(col5Input);
                     }
@@ -769,8 +774,6 @@ var Visualizer = (function ($) {
             _nce.showNote('Failed to load visualizer: ' + TWO_LINE_BREAKS + result.data);
             destroyNetwork();
             _visualizerContent.hide();
-            _visualizerInfo.hide();
-            _visualizerNetwork.hide();
             return;
         }
 
@@ -804,11 +807,12 @@ var Visualizer = (function ($) {
             _visualizerContent.show();
             _visualizerInfo.hide();
             _visualizerNetwork.hide();
+            _networkOptionsSection.hide();
         }
         else {
             destroyNetwork();
             _visualizerContent.hide();
-             message = json.message;
+            message = json.message;
             if (null !== json.stackTrace) {
                 message = message + TWO_LINE_BREAKS + json.stackTrace
             }
@@ -1352,9 +1356,6 @@ var Visualizer = (function ($) {
 
      function updateNetworkOptions()
     {
-        console.log('_networkOptions: ' + JSON.stringify(_networkOptions, null, 4));
-        console.log('_networkOptionsDefaults: ' + JSON.stringify(_networkOptionsDefaults, null, 4));
-        console.log('_networkOptionsVis: '  + JSON.stringify(_networkOptionsVis, null, 4));
         _network.setOptions(_networkOptions);
     }
 

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -84,7 +84,7 @@ var Visualizer = (function ($) {
     var _networkOptions = null;
     var _networkOptionsOverridden =
     {
-        height: '800',
+        height: '600',
         interaction: {
             navigationButtons: true,
             keyboard: {
@@ -104,7 +104,10 @@ var Visualizer = (function ($) {
                 label: {
                     enabled: true
                 }
-            }
+            },
+            shadow: {
+                enabled: true
+            },
         },
         edges: {
             arrows: {
@@ -116,6 +119,9 @@ var Visualizer = (function ($) {
                 color: 'gray'
             },
             smooth: {
+                enabled: true
+            },
+            shadow: {
                 enabled: true
             },
             hoverWidth: 3,
@@ -332,11 +338,8 @@ var Visualizer = (function ($) {
             _networkOptionsChangeSection = $('#networkOptionsChangeSection');
 
             $(window).resize(function() {
-                var height;
                 if (_network) {
-                    height = getVisNetworkHeight();
-                    _network.setSize('100%', height);
-                    _networkOptions.height = height;
+                   _network.setSize('100%', getVisNetworkHeight());
                 }
             });
 
@@ -356,7 +359,7 @@ var Visualizer = (function ($) {
                 //have a defined level. Attempted short-term fix in setLevelOnNetworkNodes() method, but it's not enough.
                 //TODO: Keep investigating, submit question and possibly a bug fix to visjs.
                 $('#hierarchical').prop('checked', false);
-                //_nce.showNote('Hierarchical mode is currently not available');
+                _nce.showNote('Hierarchical mode is currently not available');
                 //_hierarchical = this.checked;
                 //saveToLocalStorage(_hierarchical, HIERARCHICAL);
                 //updateNetworkOptions();
@@ -397,7 +400,7 @@ var Visualizer = (function ($) {
             }
             else if (FUNCTION === typeof value)
             {
-                //Not currently supporting updating of netork options that are functions.   
+                //Not currently supporting updating of netork options that are functions (only one).
             }
             else
             {
@@ -414,9 +417,10 @@ var Visualizer = (function ($) {
 
      function initNetworkOptions(container)
     {
-        var emptyDataSet, emptyNetwork, container, defaults, button;
+        var emptyDataSet, emptyNetwork, defaults, button;
         if (!_networkOptions) {
             _networkOptionsSection.hide();
+            _networkOptionsOverridden.height = getVisNetworkHeight();
             emptyDataSet = new vis.DataSet({});
             emptyNetwork = new vis.Network(container, {nodes: emptyDataSet, edges: emptyDataSet}, {});
 
@@ -1209,7 +1213,6 @@ var Visualizer = (function ($) {
             edgeDataSet = new vis.DataSet({});
             edgeDataSet.add(_edges);
             _network = new vis.Network(container, {nodes:nodeDataSet, edges:edgeDataSet}, _networkOptions);
-            _networkOptions.height = getVisNetworkHeight();
             updateNetworkData();
 
             _network.on('select', function(params) {
@@ -1276,9 +1279,9 @@ var Visualizer = (function ($) {
         }
     }
 
-     function updateNetworkOptions()
+    function updateNetworkOptions()
     {
-        _network.setOptions(_networkOptions);
+       _network.setOptions(_networkOptions);
     }
 
     function createVisualizeFromHereLink(appId, cubeName, node)


### PR DESCRIPTION
1.	Display all network options in Einstein section, not just physics options.
2.	Network option defaults loaded from Vis rather than hard coded.
3.	Load Einstein section dynamically. Removed hard coded html tags.
4.	Highlighting changes values in yellow in Einstein section.
5.	Changed network physics parm minVelocity from 0.75 to 0.85. This helps settle large networks down much faster (thanks, John!).
6.	Changed network parms to add shadows to edges and nodes. 
7.	Removed clustering feature that included overrides of Vis code. It is not working correctly (possibly since upgrading to using DataSets and new version of Vis). The feature is really not of much value now that groups can be turned on/off, levels changed and the info panel allows to navigate to a new visual. This also eliminates the single-click vs. double-click issue.
8.	General cleanup of var declarations and semi-colons to get rid of yellow IntelliJ inspections warnings.
9. Changed wording on title for edges going from an enum to a class. For example, from “Field TemplateRate with min:max cardinality of 0:1” to “Valid value TemplateRate with min:max cardinality of 0:1”.  The wording for edges going from a class to an enum remains the same. For example, “Field RateFactors with min:max cardinality of 0:999999”.