### PR TITLE
Visualizer: Changed wording on title for enums to use scoped name of source

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -414,7 +414,8 @@ class VisualizerRelInfo
 		}
 		else if (cubeName.startsWith(RPM_ENUM_DOT))
 		{
-			detailsTitle = "Valid values for field ${sourceFieldName} on ${getCubeDisplayName(sourceCube.name)}".toString()
+			String sourceName =  sourceTraitMaps ? getDotSuffix(sourceEffectiveName) : getCubeDisplayName(sourceCube.name)
+			detailsTitle = "Valid values for field ${sourceFieldName} on ${sourceName}".toString()
 		}
 		return detailsTitle
 	}


### PR DESCRIPTION
Changed wording on title for enums to use scoped name of source, if one is available. For example, from "Valid values for field RateFactors on Coverage" to "Valid values for field RateFactors on StopGapCoverage".