### PR TITLE
Visualizer: Rework how visualizer clears notes upon load from server. Update physics parms.

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -531,7 +531,7 @@ class Visualizer
 			sb.append("${BREAK}The following values are available for ${key}:${DOUBLE_BREAK}<pre><ul>")
 			scopeValues.each{
 				String value = it.toString()
-				sb.append("<li><a class=\"missingScope\" title=\"${key}: ${value}\" href=\"#\">${value}</a></li>")
+				sb.append("""<li><a class="missingScope" title="${key}: ${value}" href="#">${value}</a></li>""")
 			}
 			sb.append("</ul></pre>")
 			return sb.toString()

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -99,8 +99,8 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-md-3"><h3><img src="./img/einstein.png"/>&nbsp;&nbsp;<b>Network Options</b></h3></div>
-                        <div class="col-md-9"><a href="http://visjs.org/docs/network/" target="_blank">http://visjs.org/docs/network/ </a></div>
+                        <div class="col-md-4"><h3><img src="./img/einstein.png"/>&nbsp;&nbsp;<b>Network Options</b></h3></div>
+                        <div class="col-md-8"><a href="http://visjs.org/docs/network/" target="_blank">http://visjs.org/docs/network/ </a></div>
                     </div>
 
                     <div class="row">
@@ -108,7 +108,7 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-md-4"><b>Network status:</b></div>
+                        <div class="col-md-4" align="right"><b>Network status:</b></div>
                         <div class="col-md-1"><input id="stabilizationStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-6"><input id="iterationsToStabilize" type="text" disabled="true"></div>
@@ -119,7 +119,7 @@
                      </div>
 
                     <div class="row borders">
-                        <div class="col-md-4"><b>Parameter</b></div>
+                        <div class="col-md-4" align="right"><b>Parameter</b></div>
                         <div class="col-md-1"><b>Value</b></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><b>Default</b></div>

--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -1208,7 +1208,7 @@ var NCE = (function ($) {
         return {
             call: call,
             clearNote: clearNote,
-            clearAllNotes: clearAllNotes,
+            clearNotes: clearNotes,
             displayMap: displayMap,
             doesCubeExist: doesCubeExist,
             ensureModifiable: ensureModifiable,
@@ -4410,8 +4410,9 @@ var NCE = (function ($) {
             time: (millis || 0)
         });
         addNoteListeners();
-     }
-    
+        return _noteId;
+    }
+
     function addNoteListeners()
     {
         _noteWrapper = $.gritter.noticeWrapper();
@@ -4431,13 +4432,18 @@ var NCE = (function ($) {
             _noteId = null;
         }
     }
-    
-    function clearAllNotes()
-    {
-        $.gritter.removeAll();
-        _noteId = null;
-    }
 
+    function clearNotes(idList){
+        var id;
+        while(idList.length) {
+            id = idList.pop();
+            $.gritter.remove(id);
+            if (id === _noteId){
+                _noteId = null;
+            }
+        };
+    }
+    
     function isHeadSelected() {
         return head === _selectedBranch;
     }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -389,6 +389,7 @@ var Visualizer = (function ($) {
     };
 
     function addNetworkOptionsListeners() {
+        var button;
         $('#networkOptionsButton').click(function () {
             button = $('#networkOptionsButton');
             button.toggleClass('active');
@@ -464,7 +465,7 @@ var Visualizer = (function ($) {
     }
 
      function initNetworkOptions(container) {
-        var emptyDataSet, emptyNetwork, defaults, button;
+        var emptyDataSet, emptyNetwork, defaults;
         if (!_networkOptions) {
             _networkOptionsSection.hide();
             _networkOptionsOverridden.height = getVisNetworkHeight();
@@ -541,7 +542,7 @@ var Visualizer = (function ($) {
             else
             {
                 rowBordersDiv = $('<div/>').prop({class: "row borders"});
-                col1Div = $('<div/>').prop({class: "col-md-4"});
+                col1Div = $('<div/>').prop({class: "col-md-4", align: "right"});
                 col2Div = $('<div/>').prop({class: "col-md-1"});
                 col3Div = $('<div/>').prop({class: "col-md-1"});
                 col4Div = $('<div/>').prop({class: "col-md-2"});


### PR DESCRIPTION
1.	Rework how visualizer clears notes upon load from server. The way implemented a few days ago had issues:  One issue was that it would clear all prior notes, even those not pertaining to the visualizer (for example, a note about cubes updated from HEAD). Another issue was that a visualizer note with missing scope info would not always display when it should.
2.	Updated network physics parms for minVelocity, gravitationalConstant and springConstant.
3. Right align text in Einstein section
