### PR TITLE
Visualizer: Remove scope picker. Add tooltip with full scope on scope hover.

### DIFF
--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -17,7 +17,7 @@ div.inline-block {
 }
 
 #scope {
-    width: 97%;
+    width: 100%;
 }
 
 div.col-width-large {

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -38,7 +38,7 @@
                     <div id="scope-div" class="inline-block">
                         <div class="input-group input-group-sm col-width-large" title="Scope used to load graph data from n-cube class definitions">
                             <input id="scope" type="text" placeholder="Loading scope..." >
-                            <button id="scopeBuilderOpen" class="btn btn-default btn-xs">...</button></div>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
1.	Remove the scope picker button. It isn’t working currently because the map in the scope picker is case sensitive, which doesn’t play well with the case insensitive scope that comes across from the server (Product vs. product, etc.). Also, the scope picker is no longer needed for required scope since we provide prompts for that in toasts. The user could use the scope picker for optional scope, but the plan is to provide that functionality similar to the prompts for missing required scope. 
2.	Add tooltip with full scope on scope hover.
