### PR TITLE
Visualizer: Add link in info panel for adding types to class (risks, coverages, limits, etc.)

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -75,4 +75,8 @@ public final class VisualizerConstants
 	public static final String HTTP = 'http:'
 	public static final String HTTPS = 'https:'
 	public static final String FILE = 'file:'
+
+	public static final String TYPES_TO_ADD_NCUBE_NAME = 'visualizer.TypesToAdd'
+	public static final String SOURCE_TYPE = 'sourceType'
+	public static final String TARGET_TYPE = 'targetType'
 }

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -39,6 +39,8 @@ class VisualizerInfo
     Map<String, Set<String>> requiredScopeKeys = [:]
     Map<String, Set<String>> optionalScopeKeys = [:]
 
+    Map<String, List<String>> typesToAddMap = [:]
+
     VisualizerInfo(ApplicationID applicationID, Map options)
     {
         appId = applicationID
@@ -49,6 +51,7 @@ class VisualizerInfo
         this.selectedLevel = selectedLevel == null ? DEFAULT_LEVEL : Converter.convert(selectedLevel, long.class) as long
         availableScopeKeys =  options.availableScopeKeys as Set ?: DEFAULT_AVAILABLE_SCOPE_KEYS
         availableScopeValues = options.availableScopeValues as Map ?: loadAvailableScopeValues()
+        typesToAddMap = options.typesToAddMap as Map ?: [:]
         loadTraits = options.loadTraits as boolean
         allGroups = ALL_GROUPS_MAP
         groupSuffix = _ENUM

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -34,6 +34,7 @@ class VisualizerRelInfo
 	Map<String, Map<String, Object>> sourceTraitMaps
 	String sourceFieldName
 	String sourceFieldRpmType
+	List<String> typesToAdd
 
 	VisualizerRelInfo() {}
 
@@ -49,6 +50,7 @@ class VisualizerRelInfo
 		targetScope = node.scope as CaseInsensitiveMap
 		scope = node.availableScope as CaseInsensitiveMap
 		loadTraits = node.loadTraits as boolean
+		typesToAdd = node.typesToAdd as List
 		hasFields = node.hasFields as boolean
 		group = setGroupName()
 	}
@@ -64,16 +66,9 @@ class VisualizerRelInfo
 
 	String getDetails()
 	{
-		boolean isScopedClass = targetScopedName
 		String effectiveName = effectiveNameByCubeName
 		StringBuilder sb = new StringBuilder()
 		String notesLabel = "<b>Note: </b>"
-
-		//Scoped Name
-		if (isScopedClass)
-		{
-			sb.append("<b>Scoped name: </b>${effectiveName}${DOUBLE_BREAK}")
-		}
 
 		if (!hasFields)
 		{
@@ -91,9 +86,6 @@ class VisualizerRelInfo
 			sb.append("${DOUBLE_BREAK}")
 		}
 
-		//Level
-		sb.append("<b>Level: </b>${String.valueOf(targetLevel)}${DOUBLE_BREAK}")
-
 		//Scope
 		if (hasFields)
 		{
@@ -103,7 +95,7 @@ class VisualizerRelInfo
 			}
 			else
 			{
-				sb.append("<b>Utilized scope for minimum traits</b>")
+				sb.append("<b>Utilized scope to load class without all traits</b>")
 
 			}
 			sb.append("<pre><ul>")
@@ -356,18 +348,21 @@ class VisualizerRelInfo
 		node.scope = targetScope
 		node.availableScope = scope
 		node.fromFieldName = sourceFieldName == null ? null : sourceFieldName
-		String detailsTitle = getCubeDetailsTitle(targetCubeName)
+		String detailsTitle1 = getCubeDetailsTitle1(targetCubeName)
+		String detailsTitle2 = getCubeDetailsTitle2(targetCubeName)
 
 		if (targetCubeName.startsWith(RPM_CLASS_DOT))
 		{
 			node.label = getDotSuffix(targetEffectiveName)
-			node.detailsTitle = detailsTitle
+			node.detailsTitle1 = detailsTitle1
+			node.detailsTitle2 = detailsTitle2
 			node.title = getCubeDisplayName(targetCubeName)
+			node.typesToAdd = typesToAdd
 		}
 		else
 		{
-			node.detailsTitle = detailsTitle
-			node.title = detailsTitle
+			node.detailsTitle1 = detailsTitle1
+			node.title = detailsTitle1
 		}
 		node.details = details
 		group ?: setGroupName()
@@ -397,20 +392,12 @@ class VisualizerRelInfo
 		return displayName
 	}
 
-	String getCubeDetailsTitle(String cubeName)
+	String getCubeDetailsTitle1(String cubeName)
 	{
 		String detailsTitle
 		if (cubeName.startsWith(RPM_CLASS_DOT))
 		{
-			String targetScopedName = getTargetScopedName()
-			if (targetScopedName)
-			{
-				detailsTitle = "${getCubeDisplayName(cubeName)} ${getEffectiveNameByCubeName()}"
-			}
-			else
-			{
-				detailsTitle = getCubeDisplayName(cubeName)
-			}
+			detailsTitle = getCubeDisplayName(cubeName)
 		}
 		else if (cubeName.startsWith(RPM_ENUM_DOT))
 		{
@@ -418,5 +405,14 @@ class VisualizerRelInfo
 			detailsTitle = "Valid values for field ${sourceFieldName} on ${sourceName}".toString()
 		}
 		return detailsTitle
+	}
+
+	String getCubeDetailsTitle2(String cubeName)
+	{
+		if (cubeName.startsWith(RPM_CLASS_DOT) && getTargetScopedName())
+		{
+			return getEffectiveNameByCubeName()
+		}
+		return null
 	}
 }

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -71,6 +71,10 @@ h3{
     margin-top: 0;
 }
 
+.title1{
+    color: darkgray;
+}
+
 #groups-div {
     min-height: 47px;
 }

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -133,10 +133,13 @@
     </div>
 
     <div id="visLayoutEast" class="pane ui-layout-east" aria-disabled="false">
-        <h3 id="nodeDetailsTitle"></h3>
+        <h3 id="nodeDetailsTitle1"></h3>
+        <h3 id="nodeDetailsTitle2"></h3>
         <div id="nodeVisualizer" title="Link to new visualization with this class as the starting point"></div>
         <div id="nodeTraits" title="Show or hide traits for the class"></div>
         <div id="nodeCubeLink" title="Link to the n-cube view"></div>
+        <div id="nodeAddTypes" title="Add to this class" class="dropdown"></div>
+        <br>
         <div id="nodeDetails"></div>
     </div>
 

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -99,6 +99,7 @@ var CLASS_SECTION_NONE = 'section-none';
 var OBJECT = 'object';
 var BOOLEAN = 'boolean';
 var NUMBER = 'number';
+var STRING = 'string';
 var FUNCTION = 'function';
 
 var GLYPHICONS = {


### PR DESCRIPTION
NOTE!!!! The cube Visualizer.TypesToAdd in UD.REF.APP bheekin2 must be committed along with the merge of this PR. John, email or text me (I'll send my cell phone number separately) when you are ready so I can commit the cube, or you can go ahead and do it yourself.

1.	Added link for “Add to xxxx” in info panel. Displays dropdown of types that can be added to the class in question. For now, displays message that the add functionality is not yet implemented. The options in the dropdown are driven by a new cube Visualizer.TypesToAdd. This cube needs to be committed along with the merge of this PR.
2.	Removed level info from info panel.
3.	Removed scoped name from info panel.
4.	Split out info panel title into two titles. EPM classes uses both titles (title 1 is class name minus the rpm.class prefix, title 2 is scoped name) , all others only the first (class name minus the rpm.class prefix). For EPM classes, the first title is displayed in grey, the second in black. For all others the first title is displayed in black. 
