### PR TITLE
Visualizer: Load graph with basic options first, then load with full options + misc. other fixes

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -46,7 +46,8 @@ class VisualizerInfo
         appId = applicationID
         startCubeName = options.startCubeName as String
         scope = options.scope as CaseInsensitiveMap
-        selectedGroups = options.selectedGroups as Set ?: ALL_GROUPS_KEYS
+        Set groups = options.selectedGroups as Set
+        selectedGroups = groups == null ? ALL_GROUPS_KEYS : groups; //If null, use all groups. If empty or not empty set, use set.
         String selectedLevel = options.selectedLevel as String
         this.selectedLevel = selectedLevel == null ? DEFAULT_LEVEL : Converter.convert(selectedLevel, long.class) as long
         availableScopeKeys =  options.availableScopeKeys as Set ?: DEFAULT_AVAILABLE_SCOPE_KEYS

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -107,11 +107,36 @@
                         <div class="col-md-12">&nbsp;</div>
                     </div>
 
+                    <div class="row borders">
+                        <div class="col-md-4" align="right"><b>Task</b></div>
+                        <div class="col-md-1"><b>Status</b></div>
+                        <div class="col-md-1"></div>
+                        <div class="col-md-2"><b>Iterations</b></div>
+                        <div class="col-md-4"><b>Duration</b></div>
+                    </div>
+
                     <div class="row">
-                        <div class="col-md-4" align="right"><b>Network status:</b></div>
+                        <div class="col-md-4" align="right">Data load</div>
+                        <div class="col-md-1"><input id="dataLoadStatus" type="text" disabled="true"></div>
+                        <div class="col-md-1"></div>
+                        <div class="col-md-2">n/a</div>
+                         <div class="col-md-4"><input id="dataLoadDuration" type="text" disabled="true"></div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-4" align="right">Basic Stabilization</div>
+                        <div class="col-md-1"><input id="basicStabilizationStatus" type="text" disabled="true"></div>
+                        <div class="col-md-1"></div>
+                        <div class="col-md-2"><input id="basicStabilizationIterations" type="text" disabled="true"></div>
+                        <div class="col-md-4"><input id="basicStabilizationDuration" type="text" disabled="true"></div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-md-4" align="right">Full Stabilization</b></div>
                         <div class="col-md-1"><input id="stabilizationStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
-                        <div class="col-md-6"><input id="iterationsToStabilize" type="text" disabled="true"></div>
+                        <div class="col-md-2"><input id="stabilizationIterations" type="text" disabled="true"></div>
+                        <div class="col-md-4"><input id="sabilizationDuration" type="text" disabled="true"></div>
                     </div>
 
                     <div class="row">

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -112,11 +112,11 @@
                         <div class="col-md-1"><b>Status</b></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><b>Iterations</b></div>
-                        <div class="col-md-4"><b>Duration</b></div>
+                        <div class="col-md-4"><b>Duration (ms)</b></div>
                     </div>
 
                     <div class="row">
-                        <div class="col-md-4" align="right">Data load</div>
+                        <div class="col-md-4" align="right">Load data from server</div>
                         <div class="col-md-1"><input id="dataLoadStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2">n/a</div>
@@ -124,7 +124,7 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-md-4" align="right">Basic Stabilization</div>
+                        <div class="col-md-4" align="right">Basic network stabilization</div>
                         <div class="col-md-1"><input id="basicStabilizationStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><input id="basicStabilizationIterations" type="text" disabled="true"></div>
@@ -132,11 +132,11 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-md-4" align="right">Full Stabilization</b></div>
+                        <div class="col-md-4" align="right">Full network stabilization</b></div>
                         <div class="col-md-1"><input id="stabilizationStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
                         <div class="col-md-2"><input id="stabilizationIterations" type="text" disabled="true"></div>
-                        <div class="col-md-4"><input id="sabilizationDuration" type="text" disabled="true"></div>
+                        <div class="col-md-4"><input id="stabilizationDuration" type="text" disabled="true"></div>
                     </div>
 
                     <div class="row">

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -119,7 +119,7 @@
                         <div class="col-md-4" align="right">Load data from server</div>
                         <div class="col-md-1"><input id="dataLoadStatus" type="text" disabled="true"></div>
                         <div class="col-md-1"></div>
-                        <div class="col-md-2">n/a</div>
+                        <div class="col-md-2"></div>
                          <div class="col-md-4"><input id="dataLoadDuration" type="text" disabled="true"></div>
                     </div>
 

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -430,13 +430,10 @@ var Visualizer = (function ($) {
         });
 
         $('#networkOptionsChangeSection').change(function (e) {
-            var target = e.target;
-            $('.networkOption').each(function () {
-                var id, keys;
-                id = $(this).attr('id');
-                keys = id.split('.');
-                setNetworkOption($(this), _networkOptionsInput, keys);
-            });
+            var target, keys;
+            target = e.target;
+            keys = target.id.split('.');
+            setNetworkOption(target, _networkOptionsInput, keys);
             updateNetworkOptions();
         });
     }
@@ -471,11 +468,11 @@ var Visualizer = (function ($) {
             }
             else if (BOOLEAN === typeof value)
             {
-                options[key] = inputOption.prop('checked');
+                options[key] = inputOption.checked;
             }
             else if (NUMBER === typeof value)
             {
-                options[key] = Number(inputOption.val());
+                options[key] = Number(inputOption.value);
             }
             else if (FUNCTION === typeof value)
             {
@@ -483,7 +480,7 @@ var Visualizer = (function ($) {
             }
             else
             {
-                options[key] = inputOption.val();
+                options[key] = inputOption.value;
             }
         }
         else

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -318,12 +318,15 @@ var Visualizer = (function ($) {
 
     var _dataLoadStatus = null;
     var _dataLoadDuration = null;
+    var _dataLoadStart = null;
     var _basicStabilizationStatus = null;
     var _basicStabilizationIterations = null;
     var _basicStabilizationDuration = null;
+    var _basicStabilizationStart = null;
     var _stabilizationStatus = null;
     var _stabilizationIterations = null;
     var _stabilizationDuration = null;
+    var _stabilizationStart = null;
 
     var EAST_MIN_SIZE = 50;
     var EAST_MAX_SIZE = 1000;
@@ -746,6 +749,11 @@ var Visualizer = (function ($) {
     }
 
     function load() {
+        _dataLoadStart = performance.now();
+        _dataLoadStatus = 'loading';
+        _dataLoadDuration = '...';
+        $("#dataLoadStatus").val(_dataLoadStatus);
+        $("#dataLoadDuration").val(_dataLoadDuration);
         _nce.clearNotes(_noteIdList);
         setTimeout(function () {loadFromServer();}, PROGRESS_DELAY);
         _noteIdList.push(_nce.showNote('Loading data...'));
@@ -841,7 +849,12 @@ var Visualizer = (function ($) {
                 message = message + TWO_LINE_BREAKS + json.stackTrace
             }
             _nce.showNote('Failed to load visualizer: ' + TWO_LINE_BREAKS + message);
+            return;
         }
+        _dataLoadStatus = 'complete';
+        $("#dataLoadStatus").val(_dataLoadStatus);
+        _dataLoadDuration = Math.round(performance.now() - _dataLoadStart);
+        $("#dataLoadDuration").val(_dataLoadDuration);
     }
 
     function appIdMatch(appIdA, appIdB)
@@ -1239,29 +1252,41 @@ var Visualizer = (function ($) {
 
     function networkStartStabilizingEvent(){
         if (_basicStabilizationNewNetwork || _basicStabilizationDataChange) {
-            _basicStabilizationStatus = 'first stabilization started';
-            _basicStabilizationIterations = 'iterating...';
+            _basicStabilizationStart = performance.now();
+            _basicStabilizationStatus = 'iterating...';
+            _basicStabilizationIterations = '...';
+            _basicStabilizationDuration = '...';
             $("#basicStabilizationStatus").val(_basicStabilizationStatus);
             $("#basicStabilizationIterations").val(_basicStabilizationIterations);
+            $("#basicStabilizationDuration").val(_basicStabilizationDuration);
             _noteIdList.push(_nce.showNote('Stabilizing network with basic settings...'));
         }
         else if (_fullStabilizationAfterBasic) {
-            _stabilizationStatus = 'second stabilization started';
-            _stabilizationIterations = 'iterating...';
+            _stabilizationStart = performance.now();
+            _stabilizationStatus = 'iterating...';
+            _stabilizationIterations = '...';
+            _stabilizationDuration = '...';
             $("#stabilizationStatus").val(_stabilizationStatus);
             $("#stabilizationIterations").val(_stabilizationIterations);
+            $("#stabilizationDuration").val(_basicStabilizationDuration);
             _nce.clearNote();
             _noteIdList.push(_nce.showNote('Stabilizing network...'));
         }
         else{
+            _stabilizationStart = performance.now();
+
             _basicStabilizationStatus = 'n/a';
             _basicStabilizationIterations = 'n/a';
+            _basicStabilizationDuration = 'n/a';
             $("#basicStabilizationStatus").val(_basicStabilizationStatus);
             $("#basicStabilizationIterations").val(_basicStabilizationIterations);
-            _stabilizationStatus = 'single stabilization started';
-            _stabilizationIterations = 'iterating...';
+            $("#basicStabilizationDuration").val(_basicStabilizationDuration);
+            _stabilizationStatus = 'iterating...';
+            _stabilizationIterations = '...';
+            _stabilizationDuration = '...';
             $("#stabilizationStatus").val(_stabilizationStatus);
             $("#stabilizationIterations").val(_stabilizationIterations);
+            $("#stabilizationDuration").val(_stabilizationDuration);
             _noteIdList.push(_nce.showNote('Stabilizing network...'));
         }
     }
@@ -1303,6 +1328,8 @@ var Visualizer = (function ($) {
         $("#stabilizationStatus").val(_stabilizationStatus);
         $("#stabilizationIterations").val(_stabilizationIterations);
         _nce.clearNote();
+        _stabilizationDuration = Math.round(performance.now() - _stabilizationStart);
+        $("#stabilizationDuration").val(_stabilizationDuration);
     }
     
     function basicStabilizationComplete(iterations){
@@ -1311,6 +1338,8 @@ var Visualizer = (function ($) {
         _basicStabilizationIterations = iterations;
         $("#basicStabilizationStatus").val(_basicStabilizationStatus);
         $("#basicStabilizationIterations").val(_basicStabilizationIterations);
+        _basicStabilizationDuration = Math.round(performance.now() - _basicStabilizationStart);
+        $("#basicStabilizationDuration").val(_basicStabilizationDuration);
         updateNetworkOptions();
     }
 

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -65,6 +65,7 @@ var Visualizer = (function ($) {
     var ITERATING = 'iterating...';
     var DOT_DOT_DOT = '...';
     var NA = 'n/a';
+    var NO_GROUPS_SELECTED = 'NO GROUPS SELECTED';
 
     //Network layout parameters
     var _hierarchical = false;
@@ -455,7 +456,7 @@ var Visualizer = (function ($) {
             e.preventDefault();
             $('#groups').find('button').removeClass('active');
             _selectedGroups = [];
-            saveToLocalStorage(_selectedGroups, SELECTED_GROUPS);
+            saveToLocalStorage(NO_GROUPS_SELECTED, SELECTED_GROUPS);
             reload();
         });
     }
@@ -759,23 +760,14 @@ var Visualizer = (function ($) {
         //TODO: rpm.class.product) after a page refresh.
         _selectedCubeName = _nce.getSelectedCubeName().replace(/_/g, '.');
 
-        if (_keepCurrentScope) {
-            _keepCurrentScope = false;
-        }
-        else{
-            _scope = getFromLocalStorage(SCOPE_MAP, null);
-        }
-
-        _selectedLevel = getFromLocalStorage(SELECTED_LEVEL, null);
-        _selectedGroups = getFromLocalStorage(SELECTED_GROUPS, null);
-        _hierarchical = getFromLocalStorage(HIERARCHICAL, false);
-        _networkOptionsButton = getFromLocalStorage(NETWORK_OPTIONS_DISPLAY, false);
-
-        if ((_selectedCubeName !== _loadedCubeName) ||
+       if ((_selectedCubeName !== _loadedCubeName) ||
             (_loadedAppId && !appIdMatch(_loadedAppId, _nce.getSelectedTabAppId()))) {
             _availableScopeKeys = null;
             _availableScopeValues = null;
         }
+
+        getAllFromLocalStorage();
+        _keepCurrentScope = false;
 
         options = {
             selectedLevel: _selectedLevel,
@@ -1233,13 +1225,14 @@ var Visualizer = (function ($) {
             $("#basicStabilizationStatus").val(ITERATING);
             $("#basicStabilizationIterations").val(DOT_DOT_DOT);
             $("#basicStabilizationDuration").val(DOT_DOT_DOT);
+            $("#stabilizationStatus").val(DOT_DOT_DOT);
+            $("#stabilizationIterations").val(DOT_DOT_DOT);
+            $("#stabilizationDuration").val(DOT_DOT_DOT);
             _noteIdList.push(_nce.showNote('Stabilizing network...'));
         }
         else if (_fullStabilizationAfterBasic) {
             _stabilizationStart = performance.now();
             $("#stabilizationStatus").val(ITERATING);
-            $("#stabilizationIterations").val(DOT_DOT_DOT);
-            $("#stabilizationDuration").val(DOT_DOT_DOT);
         }
         else{
             _stabilizationStart = performance.now();
@@ -1251,7 +1244,6 @@ var Visualizer = (function ($) {
             $("#stabilizationDuration").val(DOT_DOT_DOT);
             _noteIdList.push(_nce.showNote('Stabilizing network...'));
         }
-       
     }
 
     function networkStabilizedEvent(params){
@@ -1461,6 +1453,19 @@ var Visualizer = (function ($) {
      function getFromLocalStorage(key, defaultValue) {
         var local = localStorage[getStorageKey(_nce, key)];
         return local ? JSON.parse(local) : defaultValue;
+    }
+
+    function getAllFromLocalStorage() {
+        if (!_keepCurrentScope) {
+            _scope = getFromLocalStorage(SCOPE_MAP, null);
+        }
+        _selectedGroups = getFromLocalStorage(SELECTED_GROUPS, null);
+        if (_selectedGroups === NO_GROUPS_SELECTED) {
+            _selectedGroups = [];
+        }
+        _selectedLevel = getFromLocalStorage(SELECTED_LEVEL, null);
+        _hierarchical = getFromLocalStorage(HIERARCHICAL, false);
+        _networkOptionsButton = getFromLocalStorage(NETWORK_OPTIONS_DISPLAY, false);
     }
 
     //TODO: Temporarily override this function in index.js until figured out why nce.getSelectedCubeName()


### PR DESCRIPTION
1.	Changed centralGravity network parm from 0.3 to 3.

2.	Added functionality to load the graph with basic, “fast” options first, then when stabilized, load with full options. In this process, also make sure to honor any tweaks the user might have done to the network settings. The difference between basic options and full options is as follows: 
a.	nodes.shadow.enabled: false vs. true
b.	edges.shadow.enabled: false vs. true 
c.	edges.arrows.to.enabled: false. vs. true
d.	edges.arrowStrikethrough: false vs. true

3.	General fine-tuning of how/when network data and network options are updated, when the network is destroyed and when a reload is executed.

4.	Fixed bug that caused incorrect nodes to show when doing “New visual from here” from and to the same cube.

5.	Refactored network options change event so that it handles the specific input field that was changed, rather than looping through all network option input fields.

6.	Added duration to network status info. We can take this out once we have finished tweaking the network for speed.

7.	Broke status field out on basic stabilization and full stabilization.

8.	Fixed bug that caused a load of data from server to load up all available groups when the user had previously selected “none” for groups. The difference between an empty set and a null set…

