### PR TITLE
Visualizer: Create VisualizerConfig json file + other changes

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -32,12 +32,12 @@ class Visualizer
 	 * @param options - a map containing:
 	 *            String startCubeName, name of the starting cube
 	 *            Map scope, the context for which the visualizer is loaded
-	 *            Set selectedGroups, which groups should be included in the visualization
-	 *            String selectedLevel, the depth of traversal from the start cube
 	 *            Set<String> availableScopeKeys, scope keys available in the visualization
 	 *            Map<String, Set<Object>> availableScopeValues, scope values available in the visualization, by scope key
 	 *            Map<String, List<String>> typesToAdd, type of classes that can be added to classes
 	 *            boolean loadTraits, whether to load and display traits
+	 *            Map<String, Object> networkOverridesBasic, basic network option overrides
+	 *            Map<String, Object> networkOverridesFull, full network option overrides
      * @return a map containing status, messages and visualizer information
      */
 	Map<String, Object> buildGraph(ApplicationID applicationID, Map options)
@@ -100,7 +100,7 @@ class Visualizer
 		relInfo.loadTraits = visInfo.loadTraits
 		relInfo.targetLevel = 1
 		relInfo.targetId = 1
-		relInfo.typesToAdd = getTypesToAdd(visInfo, relInfo.targetCube.name)
+		relInfo.typesToAdd = visInfo.getTypesToAdd(relInfo.targetCube.name)
 		stack.push(relInfo)
 
 		while (!stack.empty)
@@ -110,32 +110,6 @@ class Visualizer
 
 		addSets(visInfo.availableScopeKeys, visInfo.requiredScopeKeys.values() as Set)
 		addSets(visInfo.availableScopeKeys, visInfo.optionalScopeKeys.values() as Set)
-        visInfo.trimSelectedLevel()
-        visInfo.trimSelectedGroups()
-	}
-
-	List getTypesToAdd(VisualizerInfo visInfo, String cubeName)
-	{
-		List<String> typesToAdd
-		if (cubeName.startsWith(RPM_CLASS_DOT))
-		{
-			String sourceType = cubeName - RPM_CLASS_DOT
-			Map typesToAddMap = visInfo.typesToAddMap
-			if (!typesToAddMap.containsKey(sourceType))
-			{
-				NCube cube = NCubeManager.getCube(appId, TYPES_TO_ADD_NCUBE_NAME)
-				Map<String, Boolean> map = cube.getMap([(SOURCE_TYPE): sourceType, (TARGET_TYPE): [] as Set]) as Map
-				typesToAdd = map.findAll {String type, Boolean available->
-					available == true
-				}.keySet() as List
-				typesToAddMap[sourceType] = typesToAdd
-			}
-			else
-			{
-				typesToAdd = typesToAddMap[sourceType]
-			}
-		}
-		return typesToAdd
 	}
 
 	private static Set<Set> addSets(Set<String> set, Set<Set> sets)
@@ -297,7 +271,7 @@ class Visualizer
 			nextRelInfo.sourceTraitMaps = relInfo.targetTraitMaps
 			nextRelInfo.sourceId = relInfo.targetId
 			nextRelInfo.loadTraits = visInfo.loadTraits
-			nextRelInfo.typesToAdd = getTypesToAdd(visInfo, nextTargetCube.name)
+			nextRelInfo.typesToAdd = visInfo.getTypesToAdd(nextTargetCube.name)
 
 			long nextTargetTargetLevel = relInfo.targetLevel + 1
 			nextRelInfo.targetLevel = nextTargetTargetLevel

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -9,6 +9,40 @@ import groovy.transform.CompileStatic
 @CompileStatic
 public final class VisualizerConstants
 {
+	public static final String SPACE = '&nbsp;'
+	public static final String INDENT = "${SPACE}${SPACE}${SPACE}"
+	public static final String BREAK = '<br>'
+	public static final String COMMA_SPACE = ', '
+	public static final String DOUBLE_BREAK = "${BREAK}${BREAK}"
+
+	public static final String MISSING_SCOPE = 'Missing scope for '
+	public static final String UNABLE_TO_LOAD = 'Unable to load '
+	public static final String SCOPE_VALUE_NOT_FOUND = 'Scope value not found for '
+	public static final String UNSPECIFIED = 'UNSPECIFIED'
+	public static final String DEFAULT_SCOPE_VALUE = 'XXXX'
+
+	public static final String STATUS_MISSING_START_SCOPE = 'missingStartScope'
+	public static final String STATUS_SUCCESS = 'success'
+	public static final String STATUS_INVALID_START_CUBE = 'invalidStartCube'
+
+	public static final SafeSimpleDateFormat DATE_TIME_FORMAT = new SafeSimpleDateFormat('yyyy-MM-dd')
+	public static final String HTTP = 'http:'
+	public static final String HTTPS = 'https:'
+	public static final String FILE = 'file:'
+
+	public static final String JSON_FILE_PREFIX = 'config/'
+	public static final String JSON_FILE_SUFFIX = '.json'
+	public static final String VISUALIZER_CONFIG_CUBE_NAME = 'VisualizerConfig'
+	public static final String CONFIG_ITEM = 'configItem'
+	public static final String CONFIG_NETWORK_OVERRIDES_BASIC = 'networkOverridesBasic'
+	public static final String CONFIG_NETWORK_OVERRIDES_FULL = 'networkOverridesFull'
+	public static final String CONFIG_DEFAULT_LEVEL = 'defaultLevel'
+	public static final String CONFIG_ALL_GROUPS = 'allGroups'
+	public static final String CONFIG_ALL_TYPES = 'allTypes'
+	public static final String CONFIG_GROUP_SUFFIX = 'groupSuffix'
+	public static final String CUBE_TYPE = 'cubeType'
+
+	//RPM related constants
 	public static final String RPM_CLASS = 'rpm.class'
 	public static final String RPM_ENUM = 'rpm.enum'
 	public static final String RPM_CLASS_DOT = 'rpm.class.'
@@ -23,18 +57,10 @@ public final class VisualizerConstants
 	public static final String R_SCOPED_NAME = 'r:scopedName'
 	public static final String V_MIN = 'v:min'
 	public static final String V_MAX = 'v:max'
-
 	public static final String SOURCE_FIELD_NAME = 'sourceFieldName'
 	public static final String AXIS_FIELD = 'field'
 	public static final String AXIS_NAME = 'name'
 	public static final String AXIS_TRAIT = 'trait'
-
-	public static final String _ENUM = '_ENUM'
-	public static final String UNSPECIFIED = 'UNSPECIFIED'
-	//TODO: Convert this set and others that list business types from constants to using n-cubes.
-	public static final Set<String> ALL_EPM_TYPES = ['Product', 'Risk', 'Coverage', 'Container', 'Deductible', 'Limit', 'Rate', 'Ratefactor', 'Premium', 'Party', 'Place', 'Role', 'Roleplayer'] as Set
-	public static final Map<String, String> ALL_GROUPS_MAP = [PRODUCT: 'Product', FORM: 'Form', RISK: 'Risk', COVERAGE: 'Coverage', CONTAINER: 'Container', DEDUCTIBLE: 'Deductible', LIMIT: 'Limit', RATE: 'Rate', RATEFACTOR: 'Rate Factor', PREMIUM: 'Premium', PARTY: 'Party', PLACE: 'Place', ROLE: 'Role', ROLEPLAYER: 'Role Player', UNSPECIFIED: 'Unspecified']
-	public static final Set<String> ALL_GROUPS_KEYS = ALL_GROUPS_MAP.keySet()
 
 	public static final String EFFECTIVE_VERSION = '_effectiveVersion'
 	public static final String POLICY_CONTROL_DATE = 'policyControlDate'
@@ -42,50 +68,23 @@ public final class VisualizerConstants
 	public static final String BUSINESS_DIVISION_CODE = 'businessDivisionCode'
 	public static final String STATE = 'state'
 	public static final String LOCATION_STATE = 'locationState'
-	public static final Set<String> DERIVED_SCOPE_KEYS = ['product', 'risk', 'coverage', 'container', 'deductible', 'limit', 'rate', 'ratefactor', 'premium', 'party', 'place', 'role', 'roleplayer'] as Set
-	public static final Set<String> DERIVED_SOURCE_SCOPE_KEYS = ['sourceRisk', 'sourceCoverage', 'sourceContainer', 'sourceDeductible', 'sourceLimit', 'sourceRate', 'sourceRatefactor', 'sourcePremium', 'sourceParty', 'sourcePlace', 'sourceRole', 'sourceRoleplayer'] as Set
 	public static final String SOURCE_SCOPE_KEY_PREFIX = 'source'
-
 	public static final String SYSTEM_SCOPE_KEY_PREFIX = "_"
 	public static final String EFFECTIVE_VERSION_SCOPE_KEY = SYSTEM_SCOPE_KEY_PREFIX + "effectiveVersion"
-
-	public static final Set<String> DEFAULT_OPTIONAL_SCOPE_KEYS = ['action', 'businessDivisionCode', 'context', 'date', 'edition', '_effectiveVersion', 'env', 'formId', 'LocationState', 'screen', 'state', 'transaction', 'transactionsubtype', 'username', 'view'] as Set
-	public static final Set<String> DEFAULT_AVAILABLE_SCOPE_KEYS = DERIVED_SCOPE_KEYS + DERIVED_SOURCE_SCOPE_KEYS + DEFAULT_OPTIONAL_SCOPE_KEYS + [POLICY_CONTROL_DATE, QUOTE_DATE, EFFECTIVE_VERSION]
-	public static final String DEFAULT_SCOPE_VALUE = 'XXXX'
-	public static final long DEFAULT_LEVEL = 3
-
 	public static final String ENT_APP = 'ENT.APP'
 	public static final String BUSINESS_DIVISION_CUBE_NAME = 'ent.manual.BusinessDivision'
 	public static final String STATE_CUBE_NAME = 'ent.manual.State'
-
-	public static final String SPACE = '&nbsp;'
-	public static final String INDENT = "${SPACE}${SPACE}${SPACE}"
-	public static final String BREAK = '<br>'
-	public static final String COMMA_SPACE = ', '
-	public static final String DOUBLE_BREAK = "${BREAK}${BREAK}"
-
 	public static final Set<String> MANDATORY_RPM_SCOPE_KEYS = [AXIS_FIELD, AXIS_NAME, AXIS_TRAIT] as Set
-	public static final String MISSING_SCOPE = 'Missing scope for '
-	public static final String UNABLE_TO_LOAD = 'Unable to load '
-	public static final String SCOPE_VALUE_NOT_FOUND = 'Scope value not found for '
 
-	public static final String STATUS_MISSING_START_SCOPE = 'missingStartScope'
-	public static final String STATUS_SUCCESS = 'success'
-	public static final String STATUS_INVALID_START_CUBE = 'invalidStartCube'
-	public static final SafeSimpleDateFormat DATE_TIME_FORMAT = new SafeSimpleDateFormat('yyyy-MM-dd')
+	public static final String CUBE_TYPE_RPM = 'rpm'
+	public static final String CONFIG_DERIVED_SCOPE_KEYS = 'derivedScopeKeys'
 
-	public static final String HTTP = 'http:'
-	public static final String HTTPS = 'https:'
-	public static final String FILE = 'file:'
+	/*TODO: Not needed currently, but will revisit
+	public static final String CONFIG_DERIVED_SOURCE_SCOPE_KEYS = 'derivedSourceScopeKeys'
+	public static final String CONFIG_DEFAULT_OPTIONAL_SCOPE_KEYS = 'defaultOptionalScopeKeys'
+    */
 
-	public static final String TYPES_TO_ADD_NCUBE_NAME = 'visualizer.TypesToAdd'
+	public static final String TYPES_TO_ADD_CUBE_NAME = 'VisualizerTypesToAdd'
 	public static final String SOURCE_TYPE = 'sourceType'
 	public static final String TARGET_TYPE = 'targetType'
-
-	public static final String NETWORK_OVERRIDES_NCUBE_NAME = 'visualizer.NetworkOverrides'
-	public static final String OVERRIDE_TYPE = 'overrideType'
-	public static final String OVERRIDE_TYPE_BASIC = 'basic'
-	public static final String OVERRIDE_TYPE_FULL = 'full'
-	public static final String CUBE_TYPE = 'cubeType'
-	public static final String CUBE_TYPE_RPM = 'rpm'
 }

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -31,6 +31,8 @@ public final class VisualizerConstants
 
 	public static final String _ENUM = '_ENUM'
 	public static final String UNSPECIFIED = 'UNSPECIFIED'
+	//TODO: Convert this set and others that list business types from constants to using n-cubes.
+	public static final Set<String> ALL_EPM_TYPES = ['Product', 'Risk', 'Coverage', 'Container', 'Deductible', 'Limit', 'Rate', 'Ratefactor', 'Premium', 'Party', 'Place', 'Role', 'Roleplayer'] as Set
 	public static final Map<String, String> ALL_GROUPS_MAP = [PRODUCT: 'Product', FORM: 'Form', RISK: 'Risk', COVERAGE: 'Coverage', CONTAINER: 'Container', DEDUCTIBLE: 'Deductible', LIMIT: 'Limit', RATE: 'Rate', RATEFACTOR: 'Rate Factor', PREMIUM: 'Premium', PARTY: 'Party', PLACE: 'Place', ROLE: 'Role', ROLEPLAYER: 'Role Player', UNSPECIFIED: 'Unspecified']
 	public static final Set<String> ALL_GROUPS_KEYS = ALL_GROUPS_MAP.keySet()
 
@@ -79,4 +81,11 @@ public final class VisualizerConstants
 	public static final String TYPES_TO_ADD_NCUBE_NAME = 'visualizer.TypesToAdd'
 	public static final String SOURCE_TYPE = 'sourceType'
 	public static final String TARGET_TYPE = 'targetType'
+
+	public static final String NETWORK_OVERRIDES_NCUBE_NAME = 'visualizer.NetworkOverrides'
+	public static final String OVERRIDE_TYPE = 'overrideType'
+	public static final String OVERRIDE_TYPE_BASIC = 'basic'
+	public static final String OVERRIDE_TYPE_FULL = 'full'
+	public static final String CUBE_TYPE = 'cubeType'
+	public static final String CUBE_TYPE_RPM = 'rpm'
 }

--- a/src/main/resources/config/VisualizerConfig.json
+++ b/src/main/resources/config/VisualizerConfig.json
@@ -1,0 +1,172 @@
+{
+  "ncube": "VisualizerConfig",
+  "axes": [
+    {
+      "id": 2,
+      "name": "cubeType",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2001950513622,
+          "type": "string",
+          "value": "rpm"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "configItem",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "default_value": {
+        "type": "exp",
+        "value": "[:]"
+      },
+      "columns": [
+        {
+          "id": 1001273450632,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "[:]"
+          },
+          "value": "allGroups"
+        },
+        {
+          "id": 1000052809612,
+          "type": "string",
+          "value": "allTypes"
+        },
+        {
+          "id": 1000269251582,
+          "type": "string",
+          "default_value": {
+            "type": "long",
+            "value": 3
+          },
+          "value": "defaultLevel"
+        },
+        {
+          "id": 1000947844705,
+          "type": "string",
+          "value": "defaultOptionalScopeKeys"
+        },
+        {
+          "id": 1000831101323,
+          "type": "string",
+          "value": "derivedScopeKeys"
+        },
+        {
+          "id": 1000054577899,
+          "type": "string",
+          "value": "derivedSourceScopeKeys"
+        },
+        {
+          "id": 1000017855263,
+          "type": "string",
+          "value": "groupSuffix"
+        },
+        {
+          "id": 1001504517186,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "cache": true,
+            "value": "[:]"
+          },
+          "value": "networkOverridesBasic"
+        },
+        {
+          "id": 1001110976360,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "cache": true,
+            "value": "[:]"
+          },
+          "value": "networkOverridesFull"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1001504517186,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: false\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        PRODUCT: [\n                                shape: 'box',\n                                color: '#DAE4FA'\n                        ],\n                        RISK: [\n                                shape: 'box',\n                                color: '#759BEC'\n                        ],\n                        COVERAGE: [\n                                shape: 'box',\n                                color: '#113275',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        CONTAINER: [\n                                shape: 'star',\n                                color: \"#731d1d\",\n                                font: [\n                                        buttonColor: '#D8D8D8'\n                                ]\n                        ],\n                        LIMIT: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        DEDUCTIBLE: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        PREMIUM: [\n                                shape: 'ellipse',\n                                color: '#0B930B',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        RATE: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        ROLE: [\n                                shape: 'box',\n                                color: '#F59D56'\n                        ],\n                        ROLEPLAYER: [\n                                shape: 'box',\n                                color: '#F2F2F2'\n                        ],\n                        RATEFACTOR: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        PARTY: [\n                                shape: 'box',\n                                color: '#004000',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        PLACE: [\n                                shape: 'box',\n                                color: '#481849',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                        FORM: [\n                                shape: 'box',\n                                color: '#d2691e'\n                        ],\n                        PRODUCT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RISK_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        COVERAGE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        LIMIT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PREMIUM_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATEFACTOR_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLEPLAYER_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        CONTAINER_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        DEDUCTIBLE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PARTY_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PLACE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        UNSPECIFIED_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ]\n                ]\n        ]"
+    },
+    {
+      "id": [
+        1000052809612,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "['Product', 'Risk', 'Coverage', 'Container', 'Deductible', 'Limit', 'Rate', 'Ratefactor', 'Premium', 'Party', 'Place', 'Role', 'Roleplayer'] as Set"
+    },
+    {
+      "id": [
+        1000017855263,
+        2001950513622
+      ],
+      "type": "string",
+      "value": "_ENUM"
+    },
+    {
+      "id": [
+        1001273450632,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[PRODUCT: 'Product', FORM: 'Form', RISK: 'Risk', COVERAGE: 'Coverage', CONTAINER: 'Container', DEDUCTIBLE: 'Deductible', LIMIT: 'Limit', RATE: 'Rate', RATEFACTOR: 'Rate Factor', PREMIUM: 'Premium', PARTY: 'Party', PLACE: 'Place', ROLE: 'Role', ROLEPLAYER: 'Role Player', UNSPECIFIED: 'Unspecified']"
+    },
+    {
+      "id": [
+        1000054577899,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "['sourceRisk', 'sourceCoverage', 'sourceContainer', 'sourceDeductible', 'sourceLimit', 'sourceRate', 'sourceRatefactor', 'sourcePremium', 'sourceParty', 'sourcePlace', 'sourceRole', 'sourceRoleplayer'] as Set"
+    },
+    {
+      "id": [
+        1001110976360,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\nnodes: [\nshadow: [\nenabled: true\n]\n],\nedges: [\narrowStrikethrough: true,\narrows: [\nto: [\nenabled: true\n]\n],\nshadow: [\nenabled: true\n]\n]\n]"
+    },
+    {
+      "id": [
+        1000947844705,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "['action', 'businessDivisionCode', 'context', 'date', 'edition', '_effectiveVersion', 'env', 'formId', 'LocationState', 'screen', 'state', 'transaction', 'transactionsubtype', 'username', 'view'] as Set"
+    },
+    {
+      "id": [
+        1000831101323,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "['product', 'risk', 'coverage', 'container', 'deductible', 'limit', 'rate', 'ratefactor', 'premium', 'party', 'place', 'role', 'roleplayer'] as Set"
+    }
+  ]
+}

--- a/src/main/resources/config/VisualizerTypesToAdd.json
+++ b/src/main/resources/config/VisualizerTypesToAdd.json
@@ -1,0 +1,233 @@
+{
+  "ncube": "VisualizerTypesToAdd",
+  "defaultCellValueType": "boolean",
+  "defaultCellValue": false,
+  "axes": [
+    {
+      "id": 1,
+      "name": "sourceType",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1001504517186,
+          "type": "string",
+          "value": "Container"
+        },
+        {
+          "id": 1001110976360,
+          "type": "string",
+          "value": "Coverage"
+        },
+        {
+          "id": 1001912849978,
+          "type": "string",
+          "value": "Product"
+        },
+        {
+          "id": 1001410959066,
+          "type": "string",
+          "value": "Risk"
+        },
+        {
+          "id": 1001149768010,
+          "type": "string",
+          "value": "Role"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "targetType",
+      "hasDefault": false,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2000313989753,
+          "type": "string",
+          "value": "Container"
+        },
+        {
+          "id": 2001026198035,
+          "type": "string",
+          "value": "Coverage"
+        },
+        {
+          "id": 2000130791227,
+          "type": "string",
+          "value": "Deductible"
+        },
+        {
+          "id": 2000246099594,
+          "type": "string",
+          "value": "Limit"
+        },
+        {
+          "id": 2001065107849,
+          "type": "string",
+          "value": "Party"
+        },
+        {
+          "id": 2000807430939,
+          "type": "string",
+          "value": "Place"
+        },
+        {
+          "id": 2001869120121,
+          "type": "string",
+          "value": "Premium"
+        },
+        {
+          "id": 2000272056458,
+          "type": "string",
+          "value": "Product"
+        },
+        {
+          "id": 2001048454338,
+          "type": "string",
+          "value": "Rate"
+        },
+        {
+          "id": 2000996061008,
+          "type": "string",
+          "value": "Ratefactor"
+        },
+        {
+          "id": 2000060826136,
+          "type": "string",
+          "value": "Risk"
+        },
+        {
+          "id": 2000791778877,
+          "type": "string",
+          "value": "Role"
+        },
+        {
+          "id": 2000440793883,
+          "type": "string",
+          "value": "Roleplayer"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1001504517186,
+        2001869120121
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001912849978,
+        2000791778877
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2001048454338
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2001869120121
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001410959066,
+        2001026198035
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2000996061008
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001912849978,
+        2000060826136
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2001026198035
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001149768010,
+        2000440793883
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2000130791227
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2000791778877
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001110976360,
+        2000246099594
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001410959066,
+        2000060826136
+      ],
+      "type": "boolean",
+      "value": true
+    },
+    {
+      "id": [
+        1001410959066,
+        2000313989753
+      ],
+      "type": "boolean",
+      "value": true
+    }
+  ]
+}

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -101,6 +101,7 @@ var BOOLEAN = 'boolean';
 var NUMBER = 'number';
 var STRING = 'string';
 var FUNCTION = 'function';
+var BIG_DECIMAL = 'java.math.BigDecimal';
 
 var GLYPHICONS = {
     OPTION_HORIZONTAL: 'glyphicon-option-horizontal',

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -28,11 +28,11 @@ var Visualizer = (function ($) {
     var _edges = [];
     var _scope = null;
     var _keepCurrentScope = false;
-    var _availableScopeKeys = [];
+    var _availableScopeKeys = null;
+    var _availableScopeValues = null;
     var _selectedGroups = null;
     var _availableGroupsAtLevel = null;
     var _availableGroupsAllLevels = null;
-    var _availableScopeValues = {};
     var _allGroups = null;
     var _maxLevel = null;
     var _groupSuffix = null;
@@ -71,16 +71,9 @@ var Visualizer = (function ($) {
     var _hierarchical = false;
 
     //Network physics
-    var ZOOM = 0.02;
-    var NODE_SCALING = 24;
     var NODE_SCALING_SPECIAL = 200;
     var DASH_LENGTH = 15;
-    var EDGE_FONT = 20;
-    var GRAVITATIONAL_CONSTANT = -300000;
-    var MIN_VELOCITY = 5;
-    var SPRING_CONSTANT = 0.3;
-    var CENTRAL_GRAVITY = 3;
-    
+
     var _networkOptionsButton = null;
     var _networkOptionsSection = null;
     var _basicStabilizationAfterNetworkUpdate = false;
@@ -91,236 +84,8 @@ var Visualizer = (function ($) {
     var _networkOptionsDefaults = null;
     var _networkOptionsInput = null;
     var _networkOptionsInputHold = null;
-    var _networkOptionOverridesFullStabilization = {
-         nodes: {
-            shadow: {
-                enabled: true
-            }
-        },
-        edges: {
-            arrowStrikethrough: true,
-            arrows: {
-                to: {
-                    enabled: true
-                }
-            },
-            shadow: {
-                enabled: true
-            }
-        }
-    };
-
-    var _networkOptionOverridesBasicStabilization = {
-        interaction: {
-            navigationButtons: true,
-            keyboard: {
-                enabled: false,
-                speed: {
-                    x: 5,
-                    y: 5,
-                    zoom: ZOOM}
-            },
-            zoomView: true
-        },
-        nodes: {
-            value: NODE_SCALING,
-            scaling: {
-                min: NODE_SCALING,
-                max: NODE_SCALING,
-                label: {
-                    enabled: true
-                }
-            },
-            shadow: {
-                enabled: false
-            }
-        },
-        edges: {
-            arrowStrikethrough: false,
-            arrows: {
-                to: {
-                    enabled: false
-                }
-            },
-            color: {
-                color: 'gray'
-            },
-            smooth: {
-                enabled: false
-            },
-            shadow: {
-                enabled: false
-            },
-            hoverWidth: 3,
-            selectionWidth: 2,
-            font: {
-                size: EDGE_FONT
-            }
-        },
-        physics: {
-            minVelocity: MIN_VELOCITY,
-            barnesHut: {
-                gravitationalConstant: GRAVITATIONAL_CONSTANT,
-                springConstant: SPRING_CONSTANT,
-                centralGravity: CENTRAL_GRAVITY
-            }
-        },
-        layout: {
-            hierarchical: {
-                enabled: false
-            },
-            improvedLayout : true,
-            randomSeed:2
-        },
-        groups: {
-            PRODUCT: {
-                shape: 'box',
-                color: '#DAE4FA'
-            },
-            RISK: {
-                shape: 'box',
-                color: '#759BEC'
-            },
-            COVERAGE: {
-                shape: 'box',
-                color: '#113275',
-                font: {
-                    color: '#D8D8D8'
-                }
-            },
-            CONTAINER: {
-                shape: 'star',
-                color: "#731d1d",
-                font: {
-                    buttonColor: '#D8D8D8'
-                }
-            },
-            LIMIT: {
-                shape: 'ellipse',
-                color: '#FFFF99'
-            },
-            DEDUCTIBLE: {
-                shape: 'ellipse',
-                color: '#FFFF99'
-            },
-            PREMIUM: {
-                shape: 'ellipse',
-                color: '#0B930B',
-                font: {
-                    color: '#D8D8D8'
-                }
-            },
-            RATE: {
-                shape: 'ellipse',
-                color: '#EAC259'
-            },
-            ROLE: {
-                shape: 'box',
-                color: '#F59D56'
-            },
-            ROLEPLAYER: {
-                shape: 'box',
-                color: '#F2F2F2'
-            },
-            RATEFACTOR: {
-                shape: 'ellipse',
-                color: '#EAC259'
-            },
-            PARTY: {
-                shape: 'box',
-                color: '#004000',
-                font: {
-                    color: '#D8D8D8'
-                }
-            },
-            PLACE: {
-                shape: 'box',
-                color: '#481849',
-                font: {
-                    color: '#D8D8D8'
-                }
-            },
-            UNSPECIFIED: {
-                shape: 'box',
-                color: '#7ac5cd'
-            },
-            FORM: {
-                shape: 'box',
-                color: '#d2691e'
-            },
-            PRODUCT_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            RISK_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            COVERAGE_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            LIMIT_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            PREMIUM_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            RATE_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            RATEFACTOR_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            ROLE_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            ROLEPLAYER_ENUM : {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            CONTAINER_ENUM: {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            DEDUCTIBLE_ENUM: {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            PARTY_ENUM: {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            PLACE_ENUM: {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            },
-            UNSPECIFIED_ENUM: {
-                shape: 'dot',
-                scaling: {min: 5, max: 5},
-                color: 'gray'
-            }
-        }
-    };
-
+    var _networkOverridesBasic = null;
+    var _networkOverridesFull = null;
     var _dataLoadStart = null;
     var _basicStabilizationStart = null;
     var _stabilizationStart = null;
@@ -500,7 +265,7 @@ var Visualizer = (function ($) {
         var emptyDataSet, emptyNetwork, copy;
         _basicStabilizationAfterInitNetwork  = true;
         _networkOptionsSection.hide();
-        _networkOptionOverridesBasicStabilization.height = getVisNetworkHeight();
+        _networkOverridesBasic.height = getVisNetworkHeight();
         emptyDataSet = new vis.DataSet({});
         emptyNetwork = new vis.Network(container, {nodes: emptyDataSet, edges: emptyDataSet}, {});
 
@@ -519,7 +284,7 @@ var Visualizer = (function ($) {
         delete _networkOptionsVis.physics.repulsion['avoidOverlap'];
 
         copy = $.extend(true, {}, _networkOptionsVis);
-        _networkOptionsBasicStabilization = $.extend(true, copy, _networkOptionOverridesBasicStabilization);
+        _networkOptionsBasicStabilization = $.extend(true, copy, _networkOverridesBasic);
         _networkOptionsInput = $.extend(true, {}, _networkOptionsBasicStabilization);
         emptyNetwork.destroy();
     }
@@ -687,14 +452,10 @@ var Visualizer = (function ($) {
 
     function loadTraitsFromServer(node)
     {
-         var message, options, result, json, visInfo;
-         options = {
-            node: node,
-            scope: _scope,
-            availableScopeKeys: _availableScopeKeys,
-            availableScopeValues: _availableScopeValues,
-            typesToAddMap: _typesToAddMap
-        };
+        var message, options, result, json;
+
+        options = getVisualizerOptions();
+        options['node'] = node;
         
         result = _nce.call('ncubeController.getVisualizerTraits', [_nce.getSelectedTabAppId(), options]);
         _nce.clearNote();
@@ -708,23 +469,16 @@ var Visualizer = (function ($) {
         if (STATUS_SUCCESS === json.status) {
             if (null !== json.message) {
                 _noteIdList.push(_nce.showNote(json.message));
-             }
-            visInfo = json.visInfo;
-            node = visInfo.nodes['@items'][0];
-            _scope = visInfo.scope;
-            delete _scope['@type'];
-            delete _scope['@id'];
-            saveAllToLocalStorage();
-            _availableScopeValues = visInfo.availableScopeValues;
-            _availableScopeKeys = visInfo.availableScopeKeys['@items'].sort();
-            _typesToAddMap = visInfo.typesToAddMap;
+            }
+            loadData(json.visInfo, json.status);
+            node = _nodes[0];
             replaceNode(_nodes, node);
-             _nodeDetails[0].innerHTML = node.details;
+            _nodeDetails[0].innerHTML = node.details;
             _nodeTraits = $('#nodeTraits');
             _nodeAddTypes = $('#nodeAddTypes');
             _nodeTraits[0].innerHTML = '';
             _nodeTraits.append(createTraitsLink(node));
-         }
+        }
         else {
             message = json.message;
             if (null !== json.stackTrace) {
@@ -764,22 +518,15 @@ var Visualizer = (function ($) {
             (_loadedAppId && !appIdMatch(_loadedAppId, _nce.getSelectedTabAppId()))) {
             _availableScopeKeys = null;
             _availableScopeValues = null;
+            _typesToAddMap = null;
+            _networkOverridesBasic = null;
+            _networkOverridesFull = null;
         }
 
         getAllFromLocalStorage();
         _keepCurrentScope = false;
 
-        options = {
-            selectedLevel: _selectedLevel,
-            startCubeName: _selectedCubeName,
-            scope: _scope,
-            selectedGroups: _selectedGroups,
-            availableScopeKeys: _availableScopeKeys,
-            availableScopeValues: _availableScopeValues,
-            loadTraits: _loadTraits,
-            typesToAddMap: _typesToAddMap
-        };
-
+        options = getVisualizerOptions();
 
         result = _nce.call('ncubeController.getVisualizerJson', [_nce.getSelectedTabAppId(), options]);
         _nce.clearNotes(_noteIdList);
@@ -828,6 +575,19 @@ var Visualizer = (function ($) {
         }
         $("#dataLoadStatus").val(COMPLETE);
         $("#dataLoadDuration").val(Math.round(performance.now() - _dataLoadStart));
+    }
+
+    function getVisualizerOptions(){
+        return {
+            startCubeName: _selectedCubeName,
+            scope: _scope,
+            availableScopeKeys: _availableScopeKeys,
+            availableScopeValues: _availableScopeValues,
+            loadTraits: _loadTraits,
+            typesToAddMap: _typesToAddMap,
+            networkOverridesBasic: _networkOverridesBasic,
+            networkOverridesFull: _networkOverridesFull
+        }
     }
 
     function appIdMatch(appIdA, appIdB)
@@ -1124,16 +884,23 @@ var Visualizer = (function ($) {
         var nodes, edges;
 
         if (status === STATUS_SUCCESS) {
-            _allGroups = visInfo.allGroups;
-            _availableGroupsAllLevels = visInfo.availableGroupsAllLevels['@items'];
-            _selectedGroups = visInfo.selectedGroups['@items'];
-            _selectedLevel = visInfo.selectedLevel;
-            _groupSuffix = visInfo.groupSuffix;
-            _maxLevel = visInfo.maxLevel;
             nodes = visInfo.nodes['@items'];
             edges = visInfo.edges['@items'];
             _nodes =  nodes ? nodes : [];
             _edges = edges ? edges : [];
+            _allGroups = visInfo.allGroups;
+            _groupSuffix = visInfo.groupSuffix;
+            _availableGroupsAllLevels = visInfo.availableGroupsAllLevels['@items'];
+            if (_selectedGroups === null){
+                _selectedGroups = _availableGroupsAllLevels;
+            }
+            _maxLevel = visInfo.maxLevel;
+            if (_selectedLevel === null){
+                _selectedLevel = visInfo.defaultLevel;
+            }
+            if (_selectedLevel > _maxLevel){
+                _selectedLevel = _maxLevel;
+            }
         }
         _scope = visInfo.scope;
         delete _scope['@type'];
@@ -1143,7 +910,40 @@ var Visualizer = (function ($) {
         _availableScopeValues = visInfo.availableScopeValues;
         _availableScopeKeys = visInfo.availableScopeKeys['@items'].sort();
         _typesToAddMap  = visInfo.typesToAddMap;
+        _networkOverridesBasic  = visInfo.networkOverridesBasic;
+        _networkOverridesFull  = visInfo.networkOverridesFull;
+        formatNetworkOverrides(_networkOverridesBasic);
+        formatNetworkOverrides(_networkOverridesFull);
      }
+
+    function formatNetworkOverrides(overrides){
+        var valueOfValue;
+        delete overrides['@type'];
+        $.each(overrides, function (key, value)
+        {
+            if (OBJECT === typeof value){
+                valueOfValue = value.value;
+                if (undefined !== valueOfValue && OBJECT !== typeof valueOfValue)
+                {
+                    if ('java.math.BigDecimal' === value['@type']){
+                        overrides[key] = parseFloat(valueOfValue);
+                    }
+                    else if (NUMBER === typeof valueOfValue){
+                        overrides[key] = Number(valueOfValue);
+                    }
+                    else{
+                        overrides[key] = valueOfValue;
+                    }
+                }
+                else{
+                    formatNetworkOverrides(value);
+                }
+            }
+            else{
+                //primitive value
+            }
+        });
+    }
 
     function handleCubeSelected() {
         load();
@@ -1251,7 +1051,7 @@ var Visualizer = (function ($) {
         if (_basicStabilizationAfterInitNetwork) {
             _basicStabilizationAfterInitNetwork = false;
             copy = $.extend(true, {}, _networkOptionsBasicStabilization);
-            _networkOptionsDefaults = $.extend(true, copy, _networkOptionOverridesFullStabilization);
+            _networkOptionsDefaults = $.extend(true, copy, _networkOverridesFull);
             _networkOptionsInput = $.extend(true, {}, _networkOptionsDefaults);
             basicStabilizationComplete(params.iterations);
         }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -311,10 +311,12 @@ var Visualizer = (function ($) {
     function buildNetworkOptionsChangeSection(section, parentKey, networkOptions, networkOptionsDefaults, networkOptionsVis)
     {
         var rowBordersDiv, col1Div, col2Div, col3Div, col4Div, col5Div, col2Span, col2Input, col4Input, col5Input, fullKey,
-            value, keyVis, valueVis, highlightedClass, readOnly, readOnlyClass, functionTitle;
+            defaultValue, value, keys, key, k, kLen, keyVis, valueVis, highlightedClass, readOnly, readOnlyClass, functionTitle;
 
-        $.each(networkOptionsDefaults, function (key, defaultValue)
-        {
+        keys = Object.keys(networkOptionsDefaults);
+        for (k = 0, kLen = keys.length; k < kLen; k++) {
+            key = keys[k];
+            defaultValue = networkOptionsDefaults[key];
             value = networkOptions[key];
             if (networkOptionsVis)
             {
@@ -396,7 +398,7 @@ var Visualizer = (function ($) {
                 rowBordersDiv.append(col5Div);
             }
             section.append(rowBordersDiv);
-        });
+        }
     }
 
     function scopeKeyDelayLoop() {
@@ -918,10 +920,12 @@ var Visualizer = (function ($) {
 
     //TODO: Is there a better way to get the override maps from the server into the format vis.js needs?
     function formatNetworkOverrides(overrides){
-        var valueOfValue;
+        var keys,k, kLen, key, value, valueOfValue;
         delete overrides['@type'];
-        $.each(overrides, function (key, value)
-        {
+        keys = Object.keys(overrides);
+        for (k = 0, kLen = keys.length; k < kLen; k++) {
+            key = keys[k];
+            value = overrides[key];
             if (OBJECT === typeof value){
                 valueOfValue = value.value;
                 if (undefined !== valueOfValue && OBJECT !== typeof valueOfValue)
@@ -943,7 +947,7 @@ var Visualizer = (function ($) {
             else{
                 //primitive value
             }
-        });
+        }
     }
 
     function handleCubeSelected() {

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -920,7 +920,7 @@ var Visualizer = (function ($) {
 
     //TODO: Is there a better way to get the override maps from the server into the format vis.js needs?
     function formatNetworkOverrides(overrides){
-        var keys,k, kLen, key, value, valueOfValue;
+        var keys,k, kLen, key, value, valueOfValue, type;
         delete overrides['@type'];
         keys = Object.keys(overrides);
         for (k = 0, kLen = keys.length; k < kLen; k++) {
@@ -928,9 +928,11 @@ var Visualizer = (function ($) {
             value = overrides[key];
             if (OBJECT === typeof value){
                 valueOfValue = value.value;
-                if (undefined !== valueOfValue && OBJECT !== typeof valueOfValue)
+                type = value['@type'];
+                delete value['@type'];
+                if (1 === Object.keys(value).length && undefined !== valueOfValue && OBJECT !== typeof valueOfValue)
                 {
-                    if ('java.math.BigDecimal' === value['@type']){
+                    if ('java.math.BigDecimal' === type){
                         overrides[key] = parseFloat(valueOfValue);
                     }
                     else if (NUMBER === typeof valueOfValue){

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -916,6 +916,7 @@ var Visualizer = (function ($) {
         formatNetworkOverrides(_networkOverridesFull);
      }
 
+    //TODO: Is there a better way to get the override maps from the server into the format vis.js needs?
     function formatNetworkOverrides(overrides){
         var valueOfValue;
         delete overrides['@type'];


### PR DESCRIPTION
This is the reworked PR based on code review feedback + with some additional changes. 

1.	Created a new VisualizerConfig json file in NCE that holds configs for the visualizer. Configurations are only loaded first time through or if the app id changes. 
2.	Moved the TypesToAdd cube from UD.REF.APP to a json file in NCE. Also moved typesToAdd method in Visualizer.groovy into VisualizerInfo.groovy.
3.	Refactored to pass the VisualizerInfo object back and forth between the .js and the .groovy. Previously, the object was only passed down to the .js and had to be recreated in .groovy.
4.	No longer passing selectedGroups and selectedLevel back and forth from server from js. Not necessary.
5.	Commented out code relating to gathering availableScopeKeys. Not needed currently, but I will revisit this and may use it again. If not, I’ll remove the code.
6.	Removed left-over code from when we still had the feature to load traits for all nodes.
