### PR TITLE
Visualizer: Improve formatting of top node for both rpm and non-rpm visuals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <properties>
         <version.java-util>1.26.0</version.java-util>
         <version.json-io>4.9.1</version.json-io>
-        <version.ncube>3.4.121</version.ncube>
+        <version.ncube>3.4.123-SNAPSHOT</version.ncube>
         <version.json-command-servlet>1.4.0</version.json-command-servlet>
         <version.log4j>2.5</version.log4j>
         <version.groovy>2.4.7</version.groovy>

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
@@ -167,8 +167,8 @@ class RpmVisualizer extends Visualizer
 
 						if (nextTargetCubeName)
 						{
-							Set<RpmVisualizerRelInfo> set = addToStack(visInfo, relInfo, nextTargetCubeName, relInfo.sourceFieldRpmType, targetFieldName)
-							if (set && group == UNSPECIFIED_ENUM)
+							RpmVisualizerRelInfo nextRelInfo = addToStack(visInfo, relInfo, nextTargetCubeName, relInfo.sourceFieldRpmType, targetFieldName)
+							if (nextRelInfo && group == UNSPECIFIED_ENUM)
 							{
 								group = relInfo.getGroupName(visInfo, nextTargetCubeName) + visInfo.groupSuffix
 							}
@@ -193,26 +193,23 @@ class RpmVisualizer extends Visualizer
 
 	}
 
-	private Set<RpmVisualizerRelInfo> addToStack(VisualizerInfo visInfo, VisualizerRelInfo relInfo, String nextTargetCubeName, String rpmType, String targetFieldName)
+	private RpmVisualizerRelInfo addToStack(VisualizerInfo visInfo, VisualizerRelInfo relInfo, String nextTargetCubeName, String rpmType, String targetFieldName)
 	{
-		Set<RpmVisualizerRelInfo> nextRelInfoSet = super.addToStack(visInfo, relInfo, [nextTargetCubeName] as Set) as Set<RpmVisualizerRelInfo>
-		nextRelInfoSet.each { RpmVisualizerRelInfo nextRelInfo ->
-			NCube nextTargetCube = nextRelInfo.targetCube
-			try
-			{
-				nextRelInfo.scope = getScopeRelativeToSource(nextTargetCube, rpmType, targetFieldName, relInfo.scope)
-				nextRelInfo.sourceFieldName = targetFieldName
-				nextRelInfo.sourceFieldRpmType = rpmType
-				nextRelInfo.sourceTraitMaps = (relInfo as RpmVisualizerRelInfo).targetTraitMaps
-				nextRelInfo.typesToAdd = (visInfo as RpmVisualizerInfo).getTypesToAdd(nextTargetCube.name)
-			}
-
-			catch (Exception e)
-			{
-				throw new IllegalStateException("Error processing the class for field ${relInfo.sourceFieldName} in class ${nextTargetCube.name}.", e)
-			}
+		RpmVisualizerRelInfo nextRelInfo = super.addToStack(visInfo, relInfo, nextTargetCubeName) as RpmVisualizerRelInfo
+		NCube nextTargetCube = nextRelInfo.targetCube
+		try
+		{
+			nextRelInfo.scope = getScopeRelativeToSource(nextTargetCube, rpmType, targetFieldName, relInfo.scope)
+			nextRelInfo.sourceFieldName = targetFieldName
+			nextRelInfo.sourceFieldRpmType = rpmType
+			nextRelInfo.sourceTraitMaps = (relInfo as RpmVisualizerRelInfo).targetTraitMaps
+			nextRelInfo.typesToAdd = (visInfo as RpmVisualizerInfo).getTypesToAdd(nextTargetCube.name)
 		}
-		return nextRelInfoSet
+		catch (Exception e)
+		{
+			throw new IllegalStateException("Error processing the class for field ${relInfo.sourceFieldName} in class ${nextTargetCube.name}.", e)
+		}
+		return nextRelInfo
 	}
 
 	@Override

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -39,6 +39,7 @@ class VisualizerConstants
 	public static final String CONFIG_ITEM = 'configItem'
 	public static final String CONFIG_NETWORK_OVERRIDES_BASIC = 'networkOverridesBasic'
 	public static final String CONFIG_NETWORK_OVERRIDES_FULL = 'networkOverridesFull'
+	public static final String CONFIG_NETWORK_OVERRIDES_TOP_NODE = 'networkOverridesTopNode'
 	public static final String CONFIG_DEFAULT_LEVEL = 'defaultLevel'
 	public static final String CONFIG_ALL_GROUPS = 'allGroups'
 	public static final String CONFIG_ALL_TYPES = 'allTypes'

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -34,8 +34,9 @@ class VisualizerInfo
     Map<String, Set<String>> requiredScopeKeys = [:]
     Map<String, Set<String>> optionalScopeKeys = [:]
 
-    Map<String, Object> networkOverridesBasic = null
-    Map<String, Object> networkOverridesFull = null
+    Map<String, Object> networkOverridesBasic
+    Map<String, Object> networkOverridesFull
+    Map<String, Object> networkOverridesTopNode
 
     VisualizerInfo(){}
 
@@ -87,6 +88,7 @@ class VisualizerInfo
 
         networkOverridesBasic = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_BASIC, (CUBE_TYPE): cubeType]) as Map
         networkOverridesFull = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_FULL, (CUBE_TYPE): cubeType]) as Map
+        networkOverridesTopNode = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_TOP_NODE, (CUBE_TYPE): cubeType]) as Map
         defaultLevel = configCube.getCell([(CONFIG_ITEM): CONFIG_DEFAULT_LEVEL, (CUBE_TYPE): cubeType]) as long
         allGroups = configCube.getCell([(CONFIG_ITEM): CONFIG_ALL_GROUPS, (CUBE_TYPE): cubeType]) as Map
         allGroupsKeys = new LinkedHashSet(allGroups.keySet())

--- a/src/main/resources/config/VisualizerConfig.json
+++ b/src/main/resources/config/VisualizerConfig.json
@@ -93,8 +93,12 @@
           "value": "networkOverridesFull"
         },
         {
-          "id": 1000405686255,
+          "id": 1001036023421,
           "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "[:]"
+          },
           "value": "networkOverridesTopNode"
         }
       ]
@@ -164,11 +168,28 @@
     },
     {
       "id": [
+        1001036023421,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                        shapeProperties: [\n                            borderDashes: [5, 2]\n                        ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 40,\n                                max: 40\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40\n                    ];"
+    },
+    {
+      "id": [
+        1001036023421
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                        shapeProperties:\n                            [\n                                useBorderWithImage: true,\n                                borderDashes: [5, 2]\n                            ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 12,\n                                max: 12\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40,\n                        color: '#759BEC'\n                    ]"
+    },
+    {
+      "id": [
         1001504517186
       ],
       "type": "exp",
       "cache": true,
-      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 25,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true,\n\t\t\t\t\t\t\t\t\t\tmin: 12,\n\t\t\t\t\t\t\t\t\t\tmax: 12,\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: false\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ncube.png',\n\t\t\t\t\t\t\t\tcolor: '#759BEC',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#759BEC',\n                                ]\n                        ],\n                        RULE_NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ruleNcube.png',\n\t\t\t\t\t\t\t\tcolor: '#EAC259',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#EAC259',\n                                ]\n                        ],                  \n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                ]\n        ]"
+      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 25,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: false\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ncube.png',\n\t\t\t\t\t\t\t\tcolor: '#759BEC',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#759BEC',\n                                ]\n                        ],\n                        RULE_NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ruleNcube.png',\n\t\t\t\t\t\t\t\tcolor: '#EAC259',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#EAC259',\n                                ]\n                        ],                  \n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                ]\n        ]"
     },
     {
       "id": [

--- a/src/main/webapp/js/constants.js
+++ b/src/main/webapp/js/constants.js
@@ -102,6 +102,7 @@ var NUMBER = 'number';
 var STRING = 'string';
 var FUNCTION = 'function';
 var BIG_DECIMAL = 'java.math.BigDecimal';
+var ARRAY_LIST = 'java.util.ArrayList';
 
 var GLYPHICONS = {
     OPTION_HORIZONTAL: 'glyphicon-option-horizontal',


### PR DESCRIPTION
*** NOTE! *** The outstanding PR to n-cube for getReferencedCubeNames must be merged prior to merging this PR.

1. Changed to use 3.4.123-SNAPSHOT of NCube that contains the refactored NCube.getReferencedCubeNames method.
2. Changed visualizer code to use coordinate information for non-rpm cubes.
3. Improve formatting of top node for both rpm and non-rpm visuals. Move configs for this to VisualizerConfig.json.