### PR TITLE
Visualizer: First pass at values mode for non-rpm cubes

### DIFF
--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -267,8 +267,9 @@ class NCubeController extends BaseController
     // TODO: This needs to be externalized (loaded via Grapes)
     Map getVisualizerCellValues(ApplicationID appId, Map options)
     {
+        String cubeName = options.startCubeName
+        Visualizer vis = cubeName.startsWith(RpmVisualizerConstants.RPM_CLASS) ? new RpmVisualizer() : new Visualizer()
         appId = addTenant(appId)
-        RpmVisualizer vis = new RpmVisualizer()
         return vis.getCellValues(appId, options)
     }
 

--- a/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
+++ b/src/main/groovy/com/cedarsoftware/controller/NCubeController.groovy
@@ -265,11 +265,11 @@ class NCubeController extends BaseController
     }
 
     // TODO: This needs to be externalized (loaded via Grapes)
-    Map getVisualizerTraits(ApplicationID appId, Map options)
+    Map getVisualizerCellValues(ApplicationID appId, Map options)
     {
         appId = addTenant(appId)
         RpmVisualizer vis = new RpmVisualizer()
-        return vis.getTraits(appId, options)
+        return vis.getCellValues(appId, options)
     }
 
     Boolean updateCubeMetaProperties(ApplicationID appId, String cubeName, Map<String, Object> newMetaProperties)

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
@@ -41,7 +41,7 @@ class RpmVisualizer extends Visualizer
 	@Override
 	protected RpmVisualizerInfo getVisualizerInfo(Map options)
 	{
-	    RpmVisualizerInfo visInfo
+		RpmVisualizerInfo visInfo
 		Object optionsVisInfo = options.visInfo
 		if (optionsVisInfo && optionsVisInfo instanceof RpmVisualizerInfo)
 		{
@@ -50,19 +50,10 @@ class RpmVisualizer extends Visualizer
 		else
 		{
 			visInfo = new RpmVisualizerInfo(appId, options)
-			String json = NCubeManager.getResourceAsString(JSON_FILE_PREFIX + VISUALIZER_CONFIG_CUBE_NAME + JSON_FILE_SUFFIX)
-			NCube configCube = NCube.fromSimpleJson(json)
-			visInfo.loadTypesToAddMap(configCube)
 		}
+
 		visInfo.scope = options.scope as CaseInsensitiveMap ?: new CaseInsensitiveMap<>()
 		return visInfo
-	}
-
-	@Override
-	protected void loadFirstVisualizerRelInfo(VisualizerInfo visInfo, VisualizerRelInfo relInfo, String startCubeName)
-	{
-		super.loadFirstVisualizerRelInfo(visInfo, relInfo, startCubeName)
-		(relInfo as RpmVisualizerRelInfo).typesToAdd = (visInfo as RpmVisualizerInfo).getTypesToAdd(relInfo.targetCube.name)
 	}
 
 	@Override
@@ -191,7 +182,6 @@ class RpmVisualizer extends Visualizer
 			nextRelInfo.sourceFieldName = targetFieldName
 			nextRelInfo.sourceFieldRpmType = rpmType
 			nextRelInfo.sourceCellValues = (relInfo as RpmVisualizerRelInfo).targetCellValues
-			nextRelInfo.typesToAdd = (visInfo as RpmVisualizerInfo).getTypesToAdd(nextTargetCube.name)
 		}
 		catch (Exception e)
 		{

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerConstants.groovy
@@ -50,4 +50,6 @@ final class RpmVisualizerConstants extends VisualizerConstants
 	public static final String TARGET_TYPE = 'targetType'
 
 	public static final String UNSPECIFIED_ENUM = 'UNSPECIFIED_ENUM'
+
+	public static final String LOAD_CELL_VALUES_LABEL = 'traits'
 }

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerInfo.groovy
@@ -10,14 +10,12 @@ import groovy.transform.CompileStatic
 import static com.cedarsoftware.util.RpmVisualizerConstants.*
 
 /**
- * Holds information related to the visualization of cubes and their relationships.
+ * Holds information related to the visualization of rpm classes and their relationships.
  */
 
 @CompileStatic
 class RpmVisualizerInfo extends VisualizerInfo
 {
-    Map<String, List<String>> typesToAddMap = [:]
-
     RpmVisualizerInfo(){}
 
     RpmVisualizerInfo(ApplicationID applicationID, Map options)
@@ -31,22 +29,23 @@ class RpmVisualizerInfo extends VisualizerInfo
         return CUBE_TYPE_RPM
     }
 
-    List getTypesToAdd(String cubeName)
+    @Override
+    List getTypesToAdd(String group)
     {
-        if (cubeName.startsWith(RPM_CLASS_DOT))
+        if (!group.endsWith(groupSuffix))
         {
-            String sourceType = cubeName - RPM_CLASS_DOT
-            return typesToAddMap[sourceType]
+            return typesToAddMap[allGroups[group]]
         }
         return null
     }
 
+   @Override
    void loadTypesToAddMap(NCube configCube)
     {
         typesToAddMap = [:]
         String json = NCubeManager.getResourceAsString(JSON_FILE_PREFIX + TYPES_TO_ADD_CUBE_NAME + JSON_FILE_SUFFIX)
         NCube typesToAddCube = NCube.fromSimpleJson(json)
-        Set<String> allTypes = configCube.getCell([(CONFIG_ITEM): CONFIG_ALL_TYPES, (CUBE_TYPE): CUBE_TYPE_RPM]) as Set
+        Set<String> allTypes = configCube.getCell([(CONFIG_ITEM): CONFIG_ALL_TYPES, (CUBE_TYPE): getCubeType()]) as Set
 
         allTypes.each { String sourceType ->
             Map<String, Boolean> map = typesToAddCube.getMap([(SOURCE_TYPE): sourceType, (TARGET_TYPE): [] as Set]) as Map

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerInfo.groovy
@@ -58,6 +58,12 @@ class RpmVisualizerInfo extends VisualizerInfo
     }
 
     @Override
+    protected String getLoadAllCellValuesLabel()
+    {
+        LOAD_CELL_VALUES_LABEL
+    }
+
+    @Override
     void loadAvailableScopeKeysAndValues(NCube configCube)
     {
         Map<String, Set<Object>> valuesByKey = new CaseInsensitiveMap<>()

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
@@ -6,8 +6,6 @@ import com.cedarsoftware.ncube.RuleInfo
 import com.google.common.base.Splitter
 import groovy.transform.CompileStatic
 
-import static com.cedarsoftware.util.RpmVisualizerConstants.*
-
 /**
  * Holds information about a source cube and target cube for purposes of creating a visualization of the cubes and their relationship.
  */
@@ -17,22 +15,20 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 {
 	protected RpmVisualizerHelper helper = new RpmVisualizerHelper()
 	String sourceFieldRpmType
-	List<String> typesToAdd
 
     RpmVisualizerRelInfo() {}
 
-    RpmVisualizerRelInfo(ApplicationID appId, Map node)
+	RpmVisualizerRelInfo(ApplicationID appId, Map node)
 	{
 		super(appId, node)
-		typesToAdd = node.typesToAdd as List
 	}
 
-	Set<String> getRequiredScope()
+  	Set<String> getRequiredScope()
 	{
 		Set<String> requiredScope = super.requiredScope
-		requiredScope.remove(AXIS_FIELD)
-		requiredScope.remove(AXIS_NAME)
-		requiredScope.remove(AXIS_TRAIT)
+		requiredScope.remove(RpmVisualizerConstants.AXIS_FIELD)
+		requiredScope.remove(RpmVisualizerConstants.AXIS_NAME)
+		requiredScope.remove(RpmVisualizerConstants.AXIS_TRAIT)
 		return requiredScope
 	}
 
@@ -45,7 +41,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 
 		if (!cellValuesLoaded)
 		{
-			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${DOUBLE_BREAK}")
+			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${VisualizerConstants.DOUBLE_BREAK}")
 			notesLabel = "<b>Reason: </b>"
 		}
 
@@ -56,7 +52,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			notes.each { String note ->
 				sb.append("${note} ")
 			}
-			sb.append("${DOUBLE_BREAK}")
+			sb.append("${VisualizerConstants.DOUBLE_BREAK}")
 		}
 
 		//Scope
@@ -91,7 +87,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		}
 		sb.append("<pre><ul>")
 		targetCellValues.each { String fieldName, v ->
-			if (CLASS_TRAITS != fieldName)
+			if (RpmVisualizerConstants.CLASS_TRAITS != fieldName)
 			{
 				if (showAllCellValues)
 				{
@@ -115,7 +111,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			if (traitValue != null)
 			{
 				String traitString = traitValue.toString()
-				if (traitString.startsWith(HTTP) || traitString.startsWith(HTTPS) || traitString.startsWith(FILE))
+				if (traitString.startsWith(VisualizerConstants.HTTP) || traitString.startsWith(VisualizerConstants.HTTPS) || traitString.startsWith(VisualizerConstants.FILE))
 				{
 					sb.append("<li>${traitName}: <a href=\"${traitString}\" target=\"_blank\">${traitString}</a></li>")
 				}
@@ -131,8 +127,8 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	private void addClassTraits(StringBuilder sb)
 	{
 		sb.append("<b>Class traits</b>")
-		addTraits(sb, CLASS_TRAITS)
-		sb.append("${BREAK}")
+		addTraits(sb, RpmVisualizerConstants.CLASS_TRAITS)
+		sb.append("${VisualizerConstants.BREAK}")
 	}
 
 	@Override
@@ -140,7 +136,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		Iterable<String> splits = Splitter.on('.').split(cubeName)
 		String group = splits[2].toUpperCase()
-		return visInfo.allGroupsKeys.contains(group) ? group : UNSPECIFIED
+		return visInfo.allGroupsKeys.contains(group) ? group : VisualizerConstants.UNSPECIFIED
 	}
 
 	@Override
@@ -159,25 +155,25 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 
 	String getSourceScopedName()
 	{
-		Map<String, Object> classTraitsTraitMap = sourceCellValues[CLASS_TRAITS] as Map
-		return classTraitsTraitMap ? classTraitsTraitMap[R_SCOPED_NAME] : null
+		Map<String, Object> classTraitsTraitMap = sourceCellValues[RpmVisualizerConstants.CLASS_TRAITS] as Map
+		return classTraitsTraitMap ? classTraitsTraitMap[RpmVisualizerConstants.R_SCOPED_NAME] : null
 	}
 
 	String getTargetScopedName()
 	{
-		Map<String, Object> classTraitsTraitMap = targetCellValues[CLASS_TRAITS] as Map
-		return classTraitsTraitMap ? classTraitsTraitMap[R_SCOPED_NAME] : null
+		Map<String, Object> classTraitsTraitMap = targetCellValues[RpmVisualizerConstants.CLASS_TRAITS] as Map
+		return classTraitsTraitMap ? classTraitsTraitMap[RpmVisualizerConstants.R_SCOPED_NAME] : null
 	}
 
 	@Override
 	String getNextTargetCubeName(String targetFieldName)
 	{
-		if (sourceCube.getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
+		if (sourceCube.getAxis(RpmVisualizerConstants.AXIS_TRAIT).findColumn(RpmVisualizerConstants.R_SCOPED_NAME))
 		{
-			String scopedName = sourceCellValues[CLASS_TRAITS][R_SCOPED_NAME]
-			return !scopedName ?: RPM_CLASS_DOT + sourceFieldRpmType
+			String scopedName = sourceCellValues[RpmVisualizerConstants.CLASS_TRAITS][RpmVisualizerConstants.R_SCOPED_NAME]
+			return !scopedName ?: RpmVisualizerConstants.RPM_CLASS_DOT + sourceFieldRpmType
 		}
-		return RPM_CLASS_DOT + targetFieldName
+		return RpmVisualizerConstants.RPM_CLASS_DOT + targetFieldName
 	}
 
 	@Override
@@ -195,13 +191,13 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
     {
         targetCellValues = [:]
         Map output = [:]
-        if (targetCube.name.startsWith(RPM_ENUM))
+        if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM))
         {
-            helper.loadRpmClassFields(appId, RPM_ENUM, targetCube.name - RPM_ENUM_DOT, scope, targetCellValues, showAllCellValues, output)
+            helper.loadRpmClassFields(appId, RpmVisualizerConstants.RPM_ENUM, targetCube.name - RpmVisualizerConstants.RPM_ENUM_DOT, scope, targetCellValues, showAllCellValues, output)
         }
         else
         {
-            helper.loadRpmClassFields(appId, RPM_CLASS, targetCube.name - RPM_CLASS_DOT, scope, targetCellValues, showAllCellValues, output)
+            helper.loadRpmClassFields(appId, RpmVisualizerConstants.RPM_CLASS, targetCube.name - RpmVisualizerConstants.RPM_CLASS_DOT, scope, targetCellValues, showAllCellValues, output)
         }
         removeNotExistsFields()
 		addRequiredAndOptionalScopeKeys(visInfo)
@@ -213,7 +209,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
         Set<String> scopeCollector = new CaseInsensitiveSet<>()
         scopeCollector.addAll(visInfo.requiredScopeKeys[targetCube.name])
         scopeCollector.addAll(visInfo.optionalScopeKeys[targetCube.name])
-        scopeCollector << EFFECTIVE_VERSION_SCOPE_KEY
+        scopeCollector << RpmVisualizerConstants.EFFECTIVE_VERSION_SCOPE_KEY
 
         RuleInfo ruleInfo = NCube.getRuleInfo(output)
         Set keysUsed = ruleInfo.getInputKeysUsed()
@@ -225,12 +221,12 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 
     void removeNotExistsFields()
     {
-        targetCellValues.keySet().removeAll { String fieldName -> !targetCellValues[fieldName][R_EXISTS] }
+        targetCellValues.keySet().removeAll { String fieldName -> !targetCellValues[fieldName][RpmVisualizerConstants.R_EXISTS] }
     }
 
     static void cullScope(Set<String> scopeKeys, Set scopeCollector)
     {
-        scopeKeys.removeAll { String item -> !(scopeCollector.contains(item) || item.startsWith(SYSTEM_SCOPE_KEY_PREFIX)) }
+        scopeKeys.removeAll { String item -> !(scopeCollector.contains(item) || item.startsWith(RpmVisualizerConstants.SYSTEM_SCOPE_KEY_PREFIX)) }
     }
 
 	@Override
@@ -240,10 +236,10 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		Map<String, Map<String, Object>> sourceCellValues = sourceCellValues
 
 		Map<String, Map<String, Object>> sourceFieldTraitMap = sourceCellValues[sourceFieldName] as Map
-		String vMin = sourceFieldTraitMap[V_MIN] as String ?: '0'
-		String vMax = sourceFieldTraitMap[V_MAX] as String ?: '999999'
+		String vMin = sourceFieldTraitMap[RpmVisualizerConstants.V_MIN] as String ?: '0'
+		String vMax = sourceFieldTraitMap[RpmVisualizerConstants.V_MAX] as String ?: '999999'
 
-		if (targetCube.name.startsWith(RPM_ENUM_DOT))
+		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
 		{
 			edge.label = sourceFieldName
 			edge.title = "Field ${sourceFieldName} cardinality ${vMin}:${vMax}".toString()
@@ -260,18 +256,13 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	Map<String, Object> createNode(VisualizerInfo visInfo, String group = null)
 	{
 		Map<String, Object> node = super.createNode(visInfo, group)
-		if (targetCube.name.startsWith(RPM_CLASS_DOT))
-		{
-			node.typesToAdd = typesToAdd
-		}
-		else
+		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
 		{
 			node.label = null
 			node.detailsTitle2 = null
 			node.title = node.detailsTitle1
+			node.typesToAdd = null
 		}
-		node.showAllCellValues = showAllCellValues
-		node.cellValuesLoaded = cellValuesLoaded
 		return node
 	}
 
@@ -292,13 +283,13 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	String getCubeDisplayName(String cubeName)
 	{
 		String displayName
-		if (cubeName.startsWith(RPM_CLASS_DOT))
+		if (cubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
 		{
-			displayName = cubeName - RPM_CLASS_DOT
+			displayName = cubeName - RpmVisualizerConstants.RPM_CLASS_DOT
 		}
-		else if (cubeName.startsWith(RPM_ENUM_DOT))
+		else if (cubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
 		{
-			displayName = cubeName - RPM_ENUM_DOT
+			displayName = cubeName - RpmVisualizerConstants.RPM_ENUM_DOT
 		}
 		return displayName
 	}
@@ -308,18 +299,18 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		String description
 		String sourceCubeName = sourceCube.name
-		if (sourceCubeName.startsWith(RPM_CLASS_DOT))
+		if (sourceCubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
 		{
 			description = getDotSuffix(sourceEffectiveName)
 		}
-		else if (sourceCubeName.startsWith(RPM_ENUM_DOT))
+		else if (sourceCubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
 		{
 			if (targetScopedName)
 			{
 				String sourceDisplayName = getCubeDisplayName(sourceCubeName)
 				String scopeKeyForSourceOfSource = getDotPrefix(sourceDisplayName)
 				String nameOfSourceOfSource = sourceScope[scopeKeyForSourceOfSource]
-				String fieldNameSourceOfSource = sourceScope[SOURCE_FIELD_NAME]
+				String fieldNameSourceOfSource = sourceScope[RpmVisualizerConstants.SOURCE_FIELD_NAME]
 				description = "field ${fieldNameSourceOfSource} on ${nameOfSourceOfSource}".toString()
 			}
 			else{
@@ -334,11 +325,11 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		String detailsTitle
 		String targetCubeName = targetCube.name
-		if (targetCubeName.startsWith(RPM_CLASS_DOT))
+		if (targetCubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
 		{
 			detailsTitle = getCubeDisplayName(targetCubeName)
 		}
-		else if (targetCubeName.startsWith(RPM_ENUM_DOT))
+		else if (targetCubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
 		{
 			String sourceName =  sourceCellValues ? getDotSuffix(sourceEffectiveName) : getCubeDisplayName(sourceCube.name)
 			detailsTitle = "Valid values for field ${sourceFieldName} on ${sourceName}".toString()
@@ -349,7 +340,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	@Override
 	String getCubeDetailsTitle2()
 	{
-		if (targetCube.name.startsWith(RPM_CLASS_DOT) && targetScopedName)
+		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT) && targetScopedName)
 		{
 			return effectiveNameByCubeName
 		}

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
@@ -4,6 +4,7 @@ import com.cedarsoftware.ncube.ApplicationID
 import com.cedarsoftware.ncube.NCube
 import com.cedarsoftware.ncube.RuleInfo
 import com.google.common.base.Splitter
+import static com.cedarsoftware.util.RpmVisualizerConstants.*
 import groovy.transform.CompileStatic
 
 /**
@@ -16,19 +17,19 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	protected RpmVisualizerHelper helper = new RpmVisualizerHelper()
 	String sourceFieldRpmType
 
-    RpmVisualizerRelInfo() {}
+	RpmVisualizerRelInfo() {}
 
 	RpmVisualizerRelInfo(ApplicationID appId, Map node)
 	{
 		super(appId, node)
 	}
 
-  	Set<String> getRequiredScope()
+	Set<String> getRequiredScope()
 	{
 		Set<String> requiredScope = super.requiredScope
-		requiredScope.remove(RpmVisualizerConstants.AXIS_FIELD)
-		requiredScope.remove(RpmVisualizerConstants.AXIS_NAME)
-		requiredScope.remove(RpmVisualizerConstants.AXIS_TRAIT)
+		requiredScope.remove(AXIS_FIELD)
+		requiredScope.remove(AXIS_NAME)
+		requiredScope.remove(AXIS_TRAIT)
 		return requiredScope
 	}
 
@@ -39,9 +40,9 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		StringBuilder sb = new StringBuilder()
 		String notesLabel = "<b>Note: </b>"
 
-		if (!cellValuesLoaded)
+		if (false == cellValuesLoaded)
 		{
-			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${VisualizerConstants.DOUBLE_BREAK}")
+			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${DOUBLE_BREAK}")
 			notesLabel = "<b>Reason: </b>"
 		}
 
@@ -52,7 +53,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			notes.each { String note ->
 				sb.append("${note} ")
 			}
-			sb.append("${VisualizerConstants.DOUBLE_BREAK}")
+			sb.append("${DOUBLE_BREAK}")
 		}
 
 		//Scope
@@ -80,14 +81,14 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		if (showAllCellValues)
 		{
 			sb.append("<b>Fields and traits</b>")
-	}
+		}
 		else
 		{
 			sb.append("<b>Fields</b>")
 		}
 		sb.append("<pre><ul>")
 		targetCellValues.each { String fieldName, v ->
-			if (RpmVisualizerConstants.CLASS_TRAITS != fieldName)
+			if (CLASS_TRAITS != fieldName)
 			{
 				if (showAllCellValues)
 				{
@@ -111,7 +112,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			if (traitValue != null)
 			{
 				String traitString = traitValue.toString()
-				if (traitString.startsWith(VisualizerConstants.HTTP) || traitString.startsWith(VisualizerConstants.HTTPS) || traitString.startsWith(VisualizerConstants.FILE))
+				if (traitString.startsWith(HTTP) || traitString.startsWith(HTTPS) || traitString.startsWith(FILE))
 				{
 					sb.append("<li>${traitName}: <a href=\"${traitString}\" target=\"_blank\">${traitString}</a></li>")
 				}
@@ -127,8 +128,8 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	private void addClassTraits(StringBuilder sb)
 	{
 		sb.append("<b>Class traits</b>")
-		addTraits(sb, RpmVisualizerConstants.CLASS_TRAITS)
-		sb.append("${VisualizerConstants.BREAK}")
+		addTraits(sb, CLASS_TRAITS)
+		sb.append("${BREAK}")
 	}
 
 	@Override
@@ -136,7 +137,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		Iterable<String> splits = Splitter.on('.').split(cubeName)
 		String group = splits[2].toUpperCase()
-		return visInfo.allGroupsKeys.contains(group) ? group : VisualizerConstants.UNSPECIFIED
+		return visInfo.allGroupsKeys.contains(group) ? group : UNSPECIFIED
 	}
 
 	@Override
@@ -155,79 +156,79 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 
 	String getSourceScopedName()
 	{
-		Map<String, Object> classTraitsTraitMap = sourceCellValues[RpmVisualizerConstants.CLASS_TRAITS] as Map
-		return classTraitsTraitMap ? classTraitsTraitMap[RpmVisualizerConstants.R_SCOPED_NAME] : null
+		Map<String, Object> classTraitsTraitMap = sourceCellValues[CLASS_TRAITS] as Map
+		return classTraitsTraitMap ? classTraitsTraitMap[R_SCOPED_NAME] : null
 	}
 
 	String getTargetScopedName()
 	{
-		Map<String, Object> classTraitsTraitMap = targetCellValues[RpmVisualizerConstants.CLASS_TRAITS] as Map
-		return classTraitsTraitMap ? classTraitsTraitMap[RpmVisualizerConstants.R_SCOPED_NAME] : null
+		Map<String, Object> classTraitsTraitMap = targetCellValues[CLASS_TRAITS] as Map
+		return classTraitsTraitMap ? classTraitsTraitMap[R_SCOPED_NAME] : null
 	}
 
 	@Override
 	String getNextTargetCubeName(String targetFieldName)
 	{
-		if (sourceCube.getAxis(RpmVisualizerConstants.AXIS_TRAIT).findColumn(RpmVisualizerConstants.R_SCOPED_NAME))
+		if (sourceCube.getAxis(AXIS_TRAIT).findColumn(R_SCOPED_NAME))
 		{
-			String scopedName = sourceCellValues[RpmVisualizerConstants.CLASS_TRAITS][RpmVisualizerConstants.R_SCOPED_NAME]
-			return !scopedName ?: RpmVisualizerConstants.RPM_CLASS_DOT + sourceFieldRpmType
+			String scopedName = sourceCellValues[CLASS_TRAITS][R_SCOPED_NAME]
+			return !scopedName ?: RPM_CLASS_DOT + sourceFieldRpmType
 		}
-		return RpmVisualizerConstants.RPM_CLASS_DOT + targetFieldName
+		return RPM_CLASS_DOT + targetFieldName
 	}
 
 	@Override
-    String getSourceMessage()
-    {
-        if (sourceCellValues)
-        {
-            return sourceScopedName ? ", the target of ${sourceScopedName} on ${getCubeDisplayName(sourceCube.name)}" : ""
-        }
-        return ''
-    }
+	String getSourceMessage()
+	{
+		if (sourceCellValues)
+		{
+			return sourceScopedName ? ", the target of ${sourceScopedName} on ${getCubeDisplayName(sourceCube.name)}" : ""
+		}
+		return ''
+	}
 
 	@Override
-    void loadCellValues(ApplicationID appId, VisualizerInfo visInfo)
-    {
-        targetCellValues = [:]
-        Map output = [:]
-        if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM))
-        {
-            helper.loadRpmClassFields(appId, RpmVisualizerConstants.RPM_ENUM, targetCube.name - RpmVisualizerConstants.RPM_ENUM_DOT, scope, targetCellValues, showAllCellValues, output)
-        }
-        else
-        {
-            helper.loadRpmClassFields(appId, RpmVisualizerConstants.RPM_CLASS, targetCube.name - RpmVisualizerConstants.RPM_CLASS_DOT, scope, targetCellValues, showAllCellValues, output)
-        }
-        removeNotExistsFields()
+	void loadCellValues(ApplicationID appId, VisualizerInfo visInfo)
+	{
+		targetCellValues = [:]
+		Map output = [:]
+		if (targetCube.name.startsWith(RPM_ENUM))
+		{
+			helper.loadRpmClassFields(appId, RPM_ENUM, targetCube.name - RPM_ENUM_DOT, scope, targetCellValues, showAllCellValues, output)
+		}
+		else
+		{
+			helper.loadRpmClassFields(appId, RPM_CLASS, targetCube.name - RPM_CLASS_DOT, scope, targetCellValues, showAllCellValues, output)
+		}
+		removeNotExistsFields()
 		addRequiredAndOptionalScopeKeys(visInfo)
-        retainUsedScope(visInfo, output)
-    }
+		retainUsedScope(visInfo, output)
+	}
 
-    void retainUsedScope(VisualizerInfo visInfo, Map output)
-    {
-        Set<String> scopeCollector = new CaseInsensitiveSet<>()
-        scopeCollector.addAll(visInfo.requiredScopeKeys[targetCube.name])
-        scopeCollector.addAll(visInfo.optionalScopeKeys[targetCube.name])
-        scopeCollector << RpmVisualizerConstants.EFFECTIVE_VERSION_SCOPE_KEY
+	void retainUsedScope(VisualizerInfo visInfo, Map output)
+	{
+		Set<String> scopeCollector = new CaseInsensitiveSet<>()
+		scopeCollector.addAll(visInfo.requiredScopeKeys[targetCube.name])
+		scopeCollector.addAll(visInfo.optionalScopeKeys[targetCube.name])
+		scopeCollector << EFFECTIVE_VERSION_SCOPE_KEY
 
-        RuleInfo ruleInfo = NCube.getRuleInfo(output)
-        Set keysUsed = ruleInfo.getInputKeysUsed()
-        scopeCollector.addAll(keysUsed)
+		RuleInfo ruleInfo = NCube.getRuleInfo(output)
+		Set keysUsed = ruleInfo.getInputKeysUsed()
+		scopeCollector.addAll(keysUsed)
 
-        targetScope = new CaseInsensitiveMap(scope)
-        cullScope(targetScope.keySet(), scopeCollector)
-    }
+		targetScope = new CaseInsensitiveMap(scope)
+		cullScope(targetScope.keySet(), scopeCollector)
+	}
 
-    void removeNotExistsFields()
-    {
-        targetCellValues.keySet().removeAll { String fieldName -> !targetCellValues[fieldName][RpmVisualizerConstants.R_EXISTS] }
-    }
+	void removeNotExistsFields()
+	{
+		targetCellValues.keySet().removeAll { String fieldName -> !targetCellValues[fieldName][R_EXISTS] }
+	}
 
-    static void cullScope(Set<String> scopeKeys, Set scopeCollector)
-    {
-        scopeKeys.removeAll { String item -> !(scopeCollector.contains(item) || item.startsWith(RpmVisualizerConstants.SYSTEM_SCOPE_KEY_PREFIX)) }
-    }
+	static void cullScope(Set<String> scopeKeys, Set scopeCollector)
+	{
+		scopeKeys.removeAll { String item -> !(scopeCollector.contains(item) || item.startsWith(SYSTEM_SCOPE_KEY_PREFIX)) }
+	}
 
 	@Override
 	Map<String, Object> createEdge(int edgeId)
@@ -236,10 +237,10 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		Map<String, Map<String, Object>> sourceCellValues = sourceCellValues
 
 		Map<String, Map<String, Object>> sourceFieldTraitMap = sourceCellValues[sourceFieldName] as Map
-		String vMin = sourceFieldTraitMap[RpmVisualizerConstants.V_MIN] as String ?: '0'
-		String vMax = sourceFieldTraitMap[RpmVisualizerConstants.V_MAX] as String ?: '999999'
+		String vMin = sourceFieldTraitMap[V_MIN] as String ?: '0'
+		String vMax = sourceFieldTraitMap[V_MAX] as String ?: '999999'
 
-		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
+		if (targetCube.name.startsWith(RPM_ENUM_DOT))
 		{
 			edge.label = sourceFieldName
 			edge.title = "Field ${sourceFieldName} cardinality ${vMin}:${vMax}".toString()
@@ -256,7 +257,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	Map<String, Object> createNode(VisualizerInfo visInfo, String group = null)
 	{
 		Map<String, Object> node = super.createNode(visInfo, group)
-		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
+		if (targetCube.name.startsWith(RPM_ENUM_DOT))
 		{
 			node.label = null
 			node.detailsTitle2 = null
@@ -283,13 +284,13 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	String getCubeDisplayName(String cubeName)
 	{
 		String displayName
-		if (cubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
+		if (cubeName.startsWith(RPM_CLASS_DOT))
 		{
-			displayName = cubeName - RpmVisualizerConstants.RPM_CLASS_DOT
+			displayName = cubeName - RPM_CLASS_DOT
 		}
-		else if (cubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
+		else if (cubeName.startsWith(RPM_ENUM_DOT))
 		{
-			displayName = cubeName - RpmVisualizerConstants.RPM_ENUM_DOT
+			displayName = cubeName - RPM_ENUM_DOT
 		}
 		return displayName
 	}
@@ -299,18 +300,18 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		String description
 		String sourceCubeName = sourceCube.name
-		if (sourceCubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
+		if (sourceCubeName.startsWith(RPM_CLASS_DOT))
 		{
 			description = getDotSuffix(sourceEffectiveName)
 		}
-		else if (sourceCubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
+		else if (sourceCubeName.startsWith(RPM_ENUM_DOT))
 		{
 			if (targetScopedName)
 			{
 				String sourceDisplayName = getCubeDisplayName(sourceCubeName)
 				String scopeKeyForSourceOfSource = getDotPrefix(sourceDisplayName)
 				String nameOfSourceOfSource = sourceScope[scopeKeyForSourceOfSource]
-				String fieldNameSourceOfSource = sourceScope[RpmVisualizerConstants.SOURCE_FIELD_NAME]
+				String fieldNameSourceOfSource = sourceScope[SOURCE_FIELD_NAME]
 				description = "field ${fieldNameSourceOfSource} on ${nameOfSourceOfSource}".toString()
 			}
 			else{
@@ -325,11 +326,11 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		String detailsTitle
 		String targetCubeName = targetCube.name
-		if (targetCubeName.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT))
+		if (targetCubeName.startsWith(RPM_CLASS_DOT))
 		{
 			detailsTitle = getCubeDisplayName(targetCubeName)
 		}
-		else if (targetCubeName.startsWith(RpmVisualizerConstants.RPM_ENUM_DOT))
+		else if (targetCubeName.startsWith(RPM_ENUM_DOT))
 		{
 			String sourceName =  sourceCellValues ? getDotSuffix(sourceEffectiveName) : getCubeDisplayName(sourceCube.name)
 			detailsTitle = "Valid values for field ${sourceFieldName} on ${sourceName}".toString()
@@ -340,7 +341,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	@Override
 	String getCubeDetailsTitle2()
 	{
-		if (targetCube.name.startsWith(RpmVisualizerConstants.RPM_CLASS_DOT) && targetScopedName)
+		if (targetCube.name.startsWith(RPM_CLASS_DOT) && targetScopedName)
 		{
 			return effectiveNameByCubeName
 		}

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
@@ -114,7 +114,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 				String traitString = traitValue.toString()
 				if (traitString.startsWith(HTTP) || traitString.startsWith(HTTPS) || traitString.startsWith(FILE))
 				{
-					sb.append("<li>${traitName}: <a href=\"${traitString}\" target=\"_blank\">${traitString}</a></li>")
+					sb.append("""<li>${traitName}: <a href="#" onclick='window.open("${traitString}");return false;'>${traitString}</a></li>""")
 				}
 				else
 				{
@@ -190,6 +190,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	@Override
 	void loadCellValues(ApplicationID appId, VisualizerInfo visInfo)
 	{
+		cellValuesLoaded = null
 		targetCellValues = [:]
 		Map output = [:]
 		if (targetCube.name.startsWith(RPM_ENUM))
@@ -203,6 +204,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		removeNotExistsFields()
 		addRequiredAndOptionalScopeKeys(visInfo)
 		retainUsedScope(visInfo, output)
+		cellValuesLoaded = true
 	}
 
 	void retainUsedScope(VisualizerInfo visInfo, Map output)

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -78,12 +78,17 @@ class Visualizer
 
 		loadCellValues(visInfo, relInfo)
 		node.details = relInfo.getDetails(visInfo)
-		node.showAllCellValues = relInfo.showAllCellValues
 		node.cellValuesLoaded = relInfo.cellValuesLoaded
-		node.executeUrlCommandCell = relInfo.executeUrlCommandCell
-		node.executeUrlCommandCells = relInfo.executeUrlCommandCells
-		node.executeNonUrlCommandCell = relInfo.executeNonUrlCommandCell
-		node.executeNonUrlCommandCells = relInfo.executeNonUrlCommandCells
+		boolean showAllCellValues = relInfo.showAllCellValues
+		node.showAllCellValues = showAllCellValues
+		if (showAllCellValues)
+		{
+			relInfo.setExecuteTriggers(node)
+		}
+		else
+		{
+			relInfo.resetAllExecuteTriggers(node)
+		}
 		visInfo.nodes = [node]
 
 		String message = messages.empty ? null : messages.join(DOUBLE_BREAK)
@@ -95,7 +100,6 @@ class Visualizer
 		try
 		{
 			relInfo.loadCellValues(appId, visInfo)
-			relInfo.cellValuesLoaded = true
 		}
 		catch (Exception e)
 		{

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -78,10 +78,12 @@ class Visualizer
 
 		loadCellValues(visInfo, relInfo)
 		node.details = relInfo.getDetails(visInfo)
-		node.executeUrlCommandCell = null
-		node.executeUrlCommandCells = false
-		node.executeNonUrlCommandCell = null
-		node.executeNonUrlCommandCells = false
+		node.showAllCellValues = relInfo.showAllCellValues
+		node.cellValuesLoaded = relInfo.cellValuesLoaded
+		node.executeUrlCommandCell = relInfo.executeUrlCommandCell
+		node.executeUrlCommandCells = relInfo.executeUrlCommandCells
+		node.executeNonUrlCommandCell = relInfo.executeNonUrlCommandCell
+		node.executeNonUrlCommandCells = relInfo.executeNonUrlCommandCells
 		visInfo.nodes = [node]
 
 		String message = messages.empty ? null : messages.join(DOUBLE_BREAK)
@@ -239,6 +241,7 @@ class Visualizer
 		{
 			String effectiveName = relInfo.effectiveNameByCubeName
 			String msg = getCoordinateNotFoundMessage(visInfo, relInfo, axisName, value, effectiveName, cubeName)
+			relInfo.resetExecuteTriggers()
 			relInfo.notes << msg
 			messages << msg
 			return SCOPE_VALUE_NOT_FOUND
@@ -262,6 +265,7 @@ class Visualizer
 			visInfo.scope = expandedScope
 			String effectiveName = relInfo.effectiveNameByCubeName
 			String msg = getInvalidCoordinateExceptionMessage(visInfo, relInfo, missingScope, effectiveName, e.cubeName)
+			relInfo.resetExecuteTriggers()
 			relInfo.notes << msg
 			messages << msg
 			return MISSING_SCOPE
@@ -289,6 +293,7 @@ class Visualizer
 		Throwable t = getDeepestException(e)
 		String effectiveName = relInfo.effectiveNameByCubeName
 		String msg = getExceptionMessage(relInfo, effectiveName, e, t)
+		relInfo.resetExecuteTriggers()
 		relInfo.notes << msg
 		messages << msg
 		return UNABLE_TO_LOAD
@@ -330,9 +335,8 @@ ${BREAK}${messageScopeValues}"""
 
 	protected static String getExceptionMessage(VisualizerRelInfo relInfo, String effectiveName, Throwable e, Throwable t)
 	{
-		String cubeDisplayName = relInfo.getCubeDisplayName(relInfo.targetCube.name)
 		"""\
-An exception was thrown while loading for ${cubeDisplayName}${relInfo.sourceMessage} for ${effectiveName}. \
+An exception was thrown while loading coordinate ${relInfo.processingCoordinate} for ${effectiveName}${relInfo.sourceMessage}.. \
 ${DOUBLE_BREAK}<b>Message:</b> ${DOUBLE_BREAK}${e.message}${DOUBLE_BREAK}<b>Root cause: </b>\
 ${DOUBLE_BREAK}${t.toString()}${DOUBLE_BREAK}<b>Stack trace: </b>${DOUBLE_BREAK}${t.stackTrace.toString()}"""
 	}
@@ -341,14 +345,14 @@ ${DOUBLE_BREAK}${t.toString()}${DOUBLE_BREAK}<b>Stack trace: </b>${DOUBLE_BREAK}
 	{
 		StringBuilder message = new StringBuilder()
 		String messageScopeValues = getAvailableScopeValuesMessage(visInfo, cubeName, key)
-		message.append("The scope value ${value} for scope key ${key} cannot be found on axis ${key} in cube ${cubeName} for ${effectiveName}.")
+		message.append("The scope value ${value} for scope key ${key} cannot be found on axis ${key} in cube ${cubeName} for coordinate ${relInfo.processingCoordinate}.")
 		message.append("${DOUBLE_BREAK} Please supply a different value for ${key}.${BREAK}${messageScopeValues}")
 	}
 
 	protected String getInvalidCoordinateExceptionMessage(VisualizerInfo visInfo, VisualizerRelInfo relInfo, Set<String> missingScope, String effectiveName, String cubeName)
 	{
 		StringBuilder message = new StringBuilder()
-		message.append("Additional scope is required to load cube ${cubeName} for ${effectiveName}${relInfo.sourceMessage}.")
+		message.append("Additional scope is required to load coordinate ${relInfo.processingCoordinate} for ${effectiveName}${relInfo.sourceMessage}.")
 		message.append("${DOUBLE_BREAK} Please add scope value(s) for the following scope key(s): ${missingScope.join(COMMA_SPACE)}.${BREAK}")
 		missingScope.each{ String key ->
 			message.append(getAvailableScopeValuesMessage(visInfo, cubeName, key))

--- a/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/Visualizer.groovy
@@ -78,6 +78,10 @@ class Visualizer
 
 		loadCellValues(visInfo, relInfo)
 		node.details = relInfo.getDetails(visInfo)
+		node.executeUrlCommandCell = null
+		node.executeUrlCommandCells = false
+		node.executeNonUrlCommandCell = null
+		node.executeNonUrlCommandCells = false
 		visInfo.nodes = [node]
 
 		String message = messages.empty ? null : messages.join(DOUBLE_BREAK)

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -46,4 +46,6 @@ class VisualizerConstants
 	public static final String CONFIG_GROUP_SUFFIX = 'groupSuffix'
 	public static final String CUBE_TYPE = 'cubeType'
 	public static final String CUBE_TYPE_DEFAULT = null
+
+	public static final String LOAD_CELL_VALUES_LABEL = 'cell values'
 }

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -40,6 +40,8 @@ class VisualizerInfo
     Map<String, Object> networkOverridesFull
     Map<String, Object> networkOverridesTopNode
 
+    Map<String, List<String>> typesToAddMap = [:]
+
     VisualizerInfo(){}
 
     VisualizerInfo(ApplicationID applicationID, Map options)
@@ -97,11 +99,28 @@ class VisualizerInfo
         allGroupsKeys = new LinkedHashSet(allGroups.keySet())
         String groupSuffix = configCube.getCell([(CONFIG_ITEM): CONFIG_GROUP_SUFFIX, (CUBE_TYPE): cubeType]) as String
         this.groupSuffix = groupSuffix ?: ''
+        loadTypesToAddMap(configCube)
         loadAvailableScopeKeysAndValues(configCube)
         loadAllCellValuesLabel = getLoadAllCellValuesLabel()
         return configCube
     }
 
+    List getTypesToAdd(String group)
+    {
+        return typesToAddMap[allGroups[group]]
+    }
+
+    void loadTypesToAddMap(NCube configCube)
+    {
+        typesToAddMap = [:]
+        Set<String> allTypes = configCube.getCell([(CONFIG_ITEM): CONFIG_ALL_TYPES, (CUBE_TYPE): getCubeType()]) as Set
+        allTypes.each{String type ->
+            Map.Entry<String, String> entry = allGroups.find{ String key, String value ->
+                value == type
+            }
+            typesToAddMap[entry.value] = allTypes as List
+        }
+    }
 
     protected String getLoadAllCellValuesLabel()
     {

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -25,6 +25,7 @@ class VisualizerInfo
 	long nodeCount
     long relInfoCount
     long defaultLevel
+    String loadAllCellValuesLabel
 
 	Map<String,String> allGroups
     Set<String> allGroupsKeys
@@ -97,10 +98,16 @@ class VisualizerInfo
         String groupSuffix = configCube.getCell([(CONFIG_ITEM): CONFIG_GROUP_SUFFIX, (CUBE_TYPE): cubeType]) as String
         this.groupSuffix = groupSuffix ?: ''
         loadAvailableScopeKeysAndValues(configCube)
-
+        loadAllCellValuesLabel = getLoadAllCellValuesLabel()
         return configCube
     }
 
+
+    protected String getLoadAllCellValuesLabel()
+    {
+        LOAD_CELL_VALUES_LABEL
+    }
+    
     void loadAvailableScopeKeysAndValues(NCube configCube)
     {
          availableScopeValues = new CaseInsensitiveMap<>()

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -27,6 +27,11 @@ class VisualizerRelInfo
 	Map<String, Object> sourceScope
 	String sourceFieldName
 
+	boolean cellValuesLoaded = false
+	boolean showAllCellValues = false
+	Map<String, Map<String, Object>> targetCellValues
+	Map<String, Map<String, Object>> sourceCellValues
+
 	VisualizerRelInfo() {}
 
 	VisualizerRelInfo(ApplicationID appId, Map node)
@@ -39,6 +44,15 @@ class VisualizerRelInfo
 		targetLevel = Long.valueOf(node.level as String)
 		targetScope = node.scope as CaseInsensitiveMap
 		scope = node.availableScope as CaseInsensitiveMap
+		showAllCellValues = node.showAllCellValues as boolean
+		cellValuesLoaded = node.cellValuesLoaded as boolean
+	}
+
+	void loadCellValues(ApplicationID appId, VisualizerInfo visInfo)
+	{
+		targetCellValues = [:]
+		Map output = [:]
+		addRequiredAndOptionalScopeKeys(visInfo)
 	}
 
 	Set<String> getRequiredScope()

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -108,7 +108,7 @@ class VisualizerRelInfo
 				{
 					cell = targetCube.getCell(coordinate)
 				}
-				String cellString = cell ? cell.toString() : 'null'
+				String cellString = cell == null ? 'null' : cell.toString()
 				targetCellValues[processingCoordinate] = [(cellString): noExecuteCell]
 			}
 			targetCellValues.sort()

--- a/src/main/resources/config/VisualizerConfig.json
+++ b/src/main/resources/config/VisualizerConfig.json
@@ -21,14 +21,14 @@
       "id": 1,
       "name": "configItem",
       "hasDefault": false,
-      "type": "DISCRETE",
-      "valueType": "STRING",
-      "preferredOrder": 0,
-      "fireAll": true,
       "default_value": {
         "type": "exp",
         "value": "[:]"
       },
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
       "columns": [
         {
           "id": 1001273450632,
@@ -122,6 +122,14 @@
       "type": "exp",
       "cache": true,
       "value": "['Product', 'Risk', 'Coverage', 'Container', 'Deductible', 'Limit', 'Rate', 'Ratefactor', 'Premium', 'Party', 'Place', 'Role', 'Roleplayer'] as Set"
+    },
+    {
+      "id": [
+        1000052809612
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "['n-cube', 'rule cube']"
     },
     {
       "id": [

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -113,3 +113,12 @@ h3{
 .readOnly{
     background-color:rgb(235, 235, 228);
 }
+
+.executeNonUrlCommandCell{
+    color:#4B0082;
+}
+
+.executeNonUrlCommandCells{
+    color:#4B0082;
+}
+

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -103,7 +103,6 @@ h3{
 }
 
 .borders div{
-
 }
 
 .highlighted{
@@ -114,11 +113,13 @@ h3{
     background-color:rgb(235, 235, 228);
 }
 
-.executeNonUrlCommandCell{
+.executeNonUrlCommandCell, .executeNonUrlCommandCells{
+    color:#008080;
+}
+
+.executeUrlCommandCell, .executeUrlCommandCells{
     color:#4B0082;
 }
 
-.executeNonUrlCommandCells{
-    color:#4B0082;
-}
+
 

--- a/src/main/webapp/html/visualize.html
+++ b/src/main/webapp/html/visualize.html
@@ -167,7 +167,7 @@
         <h3 id="nodeDetailsTitle1"></h3>
         <h3 id="nodeDetailsTitle2"></h3>
         <div id="nodeVisualizer" title="Link to new visualization with this node as the starting point"></div>
-        <div id="nodeTraits" title="Show or hide traits for the class"></div>
+        <div id="nodeCellValues" title="Show or hide cell values for the class"></div>
         <div id="nodeCubeLink" title="Link to the n-cube view"></div>
         <div id="nodeAddTypes" title="Add to this class" class="dropdown"></div>
         <br>

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -46,7 +46,7 @@ var Visualizer = (function ($) {
     var _nodeDetailsTitle2 = null;
     var _nodeCubeLink = null;
     var _nodeVisualizer = null;
-    var _nodeTraits = null;
+    var _nodeCellValues = null;
     var _nodeAddTypes = null;
     var _nodeDetails = null;
     var _layout = null;
@@ -119,7 +119,7 @@ var Visualizer = (function ($) {
             _nodeDetailsTitle1 = $('#nodeDetailsTitle1');
             _nodeDetailsTitle2 = $('#nodeDetailsTitle2');
             _nodeCubeLink = $('#nodeCubeLink');
-            _nodeTraits = $('#nodeTraits');
+            _nodeCellValues = $('#nodeCellValues');
             _nodeAddTypes = $('#nodeAddTypes');
             _nodeVisualizer = $('#nodeVisualizer');
             _nodeDetails = $('#nodeDetails');
@@ -490,22 +490,22 @@ var Visualizer = (function ($) {
         _visualizerNetwork.show();
      }
 
-    function loadTraits(node) {
+    function loadCellValues(node) {
         _nce.clearNotes(_noteIdList);
-        setTimeout(function () {loadTraitsFromServer(node);}, PROGRESS_DELAY);
-        _nce.showNote(node.loadTraits ? 'Loading traits...' : 'Removing traits...');
+        setTimeout(function () {loadCellValuesFromServer(node);}, PROGRESS_DELAY);
+        _nce.showNote(node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Removing ' + _visInfo.loadAllCellValuesLabel + '...');
     }
 
-    function loadTraitsFromServer(node)
+    function loadCellValuesFromServer(node)
     {
         var message, options, result, json;
 
         options =  {visInfo: _visInfo, node: node};
 
-        result = _nce.call('ncubeController.getVisualizerTraits', [_nce.getSelectedTabAppId(), options]);
+        result = _nce.call('ncubeController.getVisualizerCellValues', [_nce.getSelectedTabAppId(), options]);
         _nce.clearNote();
         if (false === result.status) {
-            _nce.showNote('Failed to load traits: ' + TWO_LINE_BREAKS + result.data);
+            _nce.showNote('Failed to load ' + _visInfo.loadAllCellValuesLabel + ': ' + TWO_LINE_BREAKS + result.data);
             return node;
         }
 
@@ -521,17 +521,17 @@ var Visualizer = (function ($) {
             _nodeDataSet.add(_nodes);
             _nodes = _nodeDataSet.get();
             _nodeDetails[0].innerHTML = node.details;
-            _nodeTraits = $('#nodeTraits');
+            _nodeCellValues = $('#nodeCellValues');
             _nodeAddTypes = $('#nodeAddTypes');
-            _nodeTraits[0].innerHTML = '';
-            _nodeTraits.append(createTraitsLink(node));
+            _nodeCellValues[0].innerHTML = '';
+            _nodeCellValues.append(createCellValuesLink(node));
         }
         else {
             message = json.message;
             if (null !== json.stackTrace) {
                 message = message + TWO_LINE_BREAKS + json.stackTrace
             }
-            _nce.showNote('Failed to load traits: ' + TWO_LINE_BREAKS + message);
+            _nce.showNote('Failed to load ' + _visInfo.loadAllCellValuesLabel +  ': ' + TWO_LINE_BREAKS + message);
         }
         return node;
     }
@@ -639,7 +639,7 @@ var Visualizer = (function ($) {
         _nodeDetailsTitle2[0].innerHTML = '';
         _nodeCubeLink[0].innerHTML = '';
         _nodeVisualizer[0].innerHTML = '';
-        _nodeTraits[0].innerHTML = '';
+        _nodeCellValues[0].innerHTML = '';
         _nodeAddTypes.innerHTML = '';
         _nodeDetails[0].innerHTML = '';
         _layout.close('east');
@@ -931,7 +931,10 @@ var Visualizer = (function ($) {
             formatNetworkOverrides(_networkOverridesBasic);
             formatNetworkOverrides(_networkOverridesFull);
             formatNetworkOverrides(_networkOverridesTopNode);
+            //TODO: Figure out why the only way to make _networkOverridesTopNode work is to json stringify, then json parse.
+            _networkOverridesTopNode = JSON.parse(JSON.stringify(_networkOverridesTopNode));
         }
+
 
         if (status === STATUS_SUCCESS) {
             nodes = visInfo.nodes['@items'];
@@ -1019,9 +1022,6 @@ var Visualizer = (function ($) {
         var node, keys, k, kLen, key;
         node = _nodeDataSet.get(1);
         if (node) {
-            //TODO: Figure out why the only way to make it work is to json stringify, then json parse.
-            _networkOverridesTopNode = JSON.parse(JSON.stringify(_networkOverridesTopNode));
-
             if (_networkOverridesTopNode) {
                 keys = Object.keys(_networkOverridesTopNode);
                 for (k = 0, kLen = keys.length; k < kLen; k++) {
@@ -1186,9 +1186,9 @@ var Visualizer = (function ($) {
         _nodeCubeLink[0].innerHTML = '';
         _nodeCubeLink.append(createCubeLink(cubeName, appId));
 
-        if (node.hasFields) {
-            _nodeTraits[0].innerHTML = '';
-            _nodeTraits.append(createTraitsLink(node));
+        if (node.cellValuesLoaded) {
+            _nodeCellValues[0].innerHTML = '';
+            _nodeCellValues.append(createCellValuesLink(node));
         }
 
         _nodeAddTypes[0].innerHTML = '';
@@ -1248,21 +1248,21 @@ var Visualizer = (function ($) {
         return cubeLink;
     }
 
-    function createTraitsLink(node) {
-        var traitsLink = $('<a/>');
-        traitsLink.addClass('nc-anc');
-        if (node.loadTraits) {
-            traitsLink.html('Hide traits');
+    function createCellValuesLink(node) {
+        var cellValuesLink = $('<a/>');
+        cellValuesLink.addClass('nc-anc');
+        if (node.showAllCellValues) {
+            cellValuesLink.html('Hide ' + _visInfo.loadAllCellValuesLabel);
         }
         else {
-            traitsLink.html('Show traits');
+            cellValuesLink.html('Show ' + _visInfo.loadAllCellValuesLabel);
         }
-        traitsLink.click(function (e) {
+        cellValuesLink.click(function (e) {
             e.preventDefault();
-            node.loadTraits = !node.loadTraits;
-            loadTraits(node);
+            node.showAllCellValues = !node.showAllCellValues;
+            loadCellValues(node);
         });
-        return traitsLink;
+        return cellValuesLink;
     }
 
     function createAddTypesDropdown(typesToAdd, label) {

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -1294,7 +1294,7 @@ var Visualizer = (function ($) {
         cellValuesLink.click(function (e) {
             e.preventDefault();
             node.showAllCellValues = !node.showAllCellValues;
-            note = node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Removing ' + _visInfo.loadAllCellValuesLabel + '...'
+            note = node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Hiding ' + _visInfo.loadAllCellValuesLabel + '...'
             loadCellValues(node, note);
         });
         return cellValuesLink;

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -213,7 +213,7 @@ var Visualizer = (function ($) {
     }
 
     function onNoteClick(e) {
-        var target, id, scopeParts, key, value, params, node;
+        var target, id, scopeParts, key, value, params, node, note;
         target = e.target;
         if (target.className.indexOf('missingScope') > -1) {
             id = target.title;
@@ -230,29 +230,29 @@ var Visualizer = (function ($) {
             networkSelectNodeEvent(params);
             _nce.clearNote();
         }
-        else if (target.className.indexOf('executeNonUrlCommandCell') > -1) {
-            node = _nodeDataSet.get(target.id);
-            node.executeNonUrlCommandCell = target.title;
-            loadCellValues(node);
-            node.executeNonUrlCommandCell = false;
-        }
-        else if (target.className.indexOf('executeUrlCommandCell') > -1) {
-            node = _nodeDataSet.get(target.id);
-            node.executeUrlCommandCell = target.title;
-            loadCellValues(node);
-            node.executeUrlCommandCell = false;
-        }
         else if (target.className.indexOf('executeNonUrlCommandCells') > -1) {
             node = _nodeDataSet.get(target.id);
             node.executeNonUrlCommandCells = true;
-            loadCellValues(node);
-            node.executeNonUrlCommandCells = false;
+            note = 'Loading ' + _visInfo.loadAllCellValuesLabel + '...'
+            loadCellValues(node, note);
         }
         else if (target.className.indexOf('executeUrlCommandCells') > -1) {
             node = _nodeDataSet.get(target.id);
             node.executeUrlCommandCells = true;
-            loadCellValues(node);
-            node.executeUrlCommandCells = false;
+            note = 'Loading ' + _visInfo.loadAllCellValuesLabel + '...'
+            loadCellValues(node, note);
+        }
+        else if (target.className.indexOf('executeNonUrlCommandCell') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeNonUrlCommandCell = target.title;
+            note = 'Loading cell value for coordinate ' + target.title + '...'
+            loadCellValues(node, note);
+        }
+        else if (target.className.indexOf('executeUrlCommandCell') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeUrlCommandCell = target.title;
+            note = 'Loading cell value for coordinate ' + target.title + '...'
+            loadCellValues(node, note);
         }
     }
 
@@ -514,10 +514,10 @@ var Visualizer = (function ($) {
         _visualizerNetwork.show();
      }
 
-    function loadCellValues(node) {
+    function loadCellValues(node, note) {
         _nce.clearNotes(_noteIdList);
         setTimeout(function () {loadCellValuesFromServer(node);}, PROGRESS_DELAY);
-        _nce.showNote(node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Removing ' + _visInfo.loadAllCellValuesLabel + '...');
+        _nce.showNote(note);
     }
 
     function loadCellValuesFromServer(node)
@@ -545,6 +545,12 @@ var Visualizer = (function ($) {
             node = json.visInfo.nodes['@items'][0];
             dataSetNode = _nodeDataSet.get(node.id);
             dataSetNode.details = node.details;
+            dataSetNode.showAllCellValues = node.showAllCellValues;
+            dataSetNode.cellValuesLoaded = node.cellValuesLoaded;
+            dataSetNode.executeUrlCommandCell = node.executeUrlCommandCell;
+            dataSetNode.executeUrlCommandCells = node.executeUrlCommandCells;
+            dataSetNode.executeNonUrlCommandCell = node.executeNonUrlCommandCell;
+            dataSetNode.executeNonUrlCommandCells = node.executeNonUrlCommandCells;
             _nodeDataSet.update(dataSetNode);
             _nodes = _nodeDataSet.get();
             _nodeDetails[0].innerHTML = node.details;
@@ -1214,10 +1220,10 @@ var Visualizer = (function ($) {
         _nodeCubeLink[0].innerHTML = '';
         _nodeCubeLink.append(createCubeLink(cubeName, appId));
 
-        //if (node.cellValuesLoaded) {//TODO
+        if (false !== node.cellValuesLoaded) {
             _nodeCellValues[0].innerHTML = '';
             _nodeCellValues.append(createCellValuesLink(node));
-        //}
+        }
 
         _nodeAddTypes[0].innerHTML = '';
         if (node.typesToAdd) {
@@ -1277,7 +1283,7 @@ var Visualizer = (function ($) {
     }
 
     function createCellValuesLink(node) {
-        var cellValuesLink = $('<a/>');
+        var note, cellValuesLink = $('<a/>');
         cellValuesLink.addClass('nc-anc');
         if (node.showAllCellValues) {
             cellValuesLink.html('Hide ' + _visInfo.loadAllCellValuesLabel);
@@ -1288,7 +1294,8 @@ var Visualizer = (function ($) {
         cellValuesLink.click(function (e) {
             e.preventDefault();
             node.showAllCellValues = !node.showAllCellValues;
-            loadCellValues(node);
+            note = node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Removing ' + _visInfo.loadAllCellValuesLabel + '...'
+            loadCellValues(node, note);
         });
         return cellValuesLink;
     }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -232,13 +232,13 @@ var Visualizer = (function ($) {
         }
         else if (target.className.indexOf('executeNonUrlCommandCell') > -1) {
             node = _nodeDataSet.get(target.id);
-            node.executeNonUrlCommandCell = true;
+            node.executeNonUrlCommandCell = target.title;
             loadCellValues(node);
             node.executeNonUrlCommandCell = false;
         }
         else if (target.className.indexOf('executeUrlCommandCell') > -1) {
             node = _nodeDataSet.get(target.id);
-            node.executeUrlCommandCell = true;
+            node.executeUrlCommandCell = target.title;
             loadCellValues(node);
             node.executeUrlCommandCell = false;
         }

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -213,7 +213,7 @@ var Visualizer = (function ($) {
     }
 
     function onNoteClick(e) {
-        var target, id, scopeParts, key, value, params;
+        var target, id, scopeParts, key, value, params, node;
         target = e.target;
         if (target.className.indexOf('missingScope') > -1) {
             id = target.title;
@@ -229,6 +229,30 @@ var Visualizer = (function ($) {
             _network.selectNodes([id]);
             networkSelectNodeEvent(params);
             _nce.clearNote();
+        }
+        else if (target.className.indexOf('executeNonUrlCommandCell') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeNonUrlCommandCell = true;
+            loadCellValues(node);
+            node.executeNonUrlCommandCell = false;
+        }
+        else if (target.className.indexOf('executeUrlCommandCell') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeUrlCommandCell = true;
+            loadCellValues(node);
+            node.executeUrlCommandCell = false;
+        }
+        else if (target.className.indexOf('executeNonUrlCommandCells') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeNonUrlCommandCells = true;
+            loadCellValues(node);
+            node.executeNonUrlCommandCells = false;
+        }
+        else if (target.className.indexOf('executeUrlCommandCells') > -1) {
+            node = _nodeDataSet.get(target.id);
+            node.executeUrlCommandCells = true;
+            loadCellValues(node);
+            node.executeUrlCommandCells = false;
         }
     }
 
@@ -503,7 +527,7 @@ var Visualizer = (function ($) {
         _visInfo.nodes = {};
         _visInfo.edges = {};
 
-        options =  {visInfo: _visInfo, node: node};
+        options =  {startCubeName: _selectedCubeName, visInfo: _visInfo, node: node};
 
         result = _nce.call('ncubeController.getVisualizerCellValues', [_nce.getSelectedTabAppId(), options]);
         _nce.clearNote();
@@ -1190,10 +1214,10 @@ var Visualizer = (function ($) {
         _nodeCubeLink[0].innerHTML = '';
         _nodeCubeLink.append(createCubeLink(cubeName, appId));
 
-        if (node.cellValuesLoaded) {
+        //if (node.cellValuesLoaded) {//TODO
             _nodeCellValues[0].innerHTML = '';
             _nodeCellValues.append(createCellValuesLink(node));
-        }
+        //}
 
         _nodeAddTypes[0].innerHTML = '';
         if (node.typesToAdd) {

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -20,6 +20,7 @@
 
 var Visualizer = (function ($) {
 
+    var _tempNote = null;
     var _network = null;
     var _nodeDataSet = null;
     var _edgeDataSet = null;
@@ -1172,6 +1173,10 @@ var Visualizer = (function ($) {
     
     function stabilizationComplete(iterations){
         _nce.clearNote();
+        if (_tempNote) {
+            _nce.showNote(_tempNote, 'Note', 5000);
+        }
+        _tempNote = null;
         $("#stabilizationStatus").val(COMPLETE);
         $("#stabilizationIterations").val(iterations);
         $("#stabilizationDuration").val(Math.round(performance.now() - _stabilizationStart));
@@ -1294,7 +1299,10 @@ var Visualizer = (function ($) {
         cellValuesLink.click(function (e) {
             e.preventDefault();
             node.showAllCellValues = !node.showAllCellValues;
-            note = node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Hiding ' + _visInfo.loadAllCellValuesLabel + '...'
+            note = node.showAllCellValues ? 'Loading ' + _visInfo.loadAllCellValuesLabel + '...' : 'Hiding ' + _visInfo.loadAllCellValuesLabel + '...';
+            if (node.showAllCellValues && _visInfo['@type'] === 'com.cedarsoftware.util.VisualizerInfo'){
+                _tempNote = 'Showing cell values is still *** UNDER CONSTRUCTION ***<BR><BR>Better display of cell values and better exception handling is on the way.';
+            }
             loadCellValues(node, note);
         });
         return cellValuesLink;

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -505,10 +505,10 @@ var Visualizer = (function ($) {
 
         options =  {visInfo: _visInfo, node: node};
 
-        result = _nce.call('ncubeController.getVisualizerTraits', [_nce.getSelectedTabAppId(), options]);
+        result = _nce.call('ncubeController.getVisualizerCellValues', [_nce.getSelectedTabAppId(), options]);
         _nce.clearNote();
         if (false === result.status) {
-            _nce.showNote('Failed to load traits: ' + TWO_LINE_BREAKS + result.data);
+            _nce.showNote('Failed to load ' + _visInfo.loadAllCellValuesLabel + ': ' + TWO_LINE_BREAKS + result.data);
             return node;
         }
 
@@ -936,7 +936,7 @@ var Visualizer = (function ($) {
             formatNetworkOverrides(_networkOverridesBasic);
             formatNetworkOverrides(_networkOverridesFull);
             formatNetworkOverrides(_networkOverridesTopNode);
-            //TODO: Figure out why the only way to make it work is to json stringify, then json parse.
+            //TODO: Figure out why the only way to make _networkOverridesTopNode work is to json stringify, then json parse.
             _networkOverridesTopNode = JSON.parse(JSON.stringify(_networkOverridesTopNode));
         }
 


### PR DESCRIPTION
1.	Refactored groovy classes and js to support loading of cell values for non-rpm cubes.  
2.	Click “Show cell values” in info panel on an non-rpm cube and you now see coordinates loaded with cell values. The default is to not execute command cells, but the user can click the coordinate link and have the cell be executed (or click execute all). The “CubeWithLotsOfDifferentValues” in bheekin2 is a good example.
3.	The loading and executing of cells seems to be working mostly OK by now, but I have an “under construction” message up for the Show Value section for non-rpm cubes since it still needs plenty more work. 
4.	Will work on exception handling and coordinate display next, among other things. 
5.	Hoping for lots of feedback on this PR! So many possibilities.
