### PR TITLE
Visualizer: Misc. small fixes

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizer.groovy
@@ -39,7 +39,7 @@ class RpmVisualizer extends Visualizer
 	}
 
 	@Override
-	protected RpmVisualizerInfo getVisualizerInfo(Map options)
+	protected VisualizerInfo getVisualizerInfo(Map options)
 	{
 		RpmVisualizerInfo visInfo
 		Object optionsVisInfo = options.visInfo
@@ -191,7 +191,7 @@ class RpmVisualizer extends Visualizer
 	}
 
 	@Override
-	protected RpmVisualizerRelInfo getVisualizerRelInfo()
+	protected VisualizerRelInfo getVisualizerRelInfo()
 	{
 		return new RpmVisualizerRelInfo()
 	}

--- a/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/RpmVisualizerRelInfo.groovy
@@ -24,6 +24,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 		super(appId, node)
 	}
 
+	@Override
 	Set<String> getRequiredScope()
 	{
 		Set<String> requiredScope = super.requiredScope
@@ -42,7 +43,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 
 		if (false == cellValuesLoadedOk)
 		{
-			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${VisualizerConstants.DOUBLE_BREAK}")
+			sb.append("<b>*** Unable to load fields and traits for ${effectiveName}</b>${DOUBLE_BREAK}")
 			notesLabel = "<b>Reason: </b>"
 		}
 
@@ -53,7 +54,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			notes.each { String note ->
 				sb.append("${note} ")
 			}
-			sb.append("${VisualizerConstants.DOUBLE_BREAK}")
+			sb.append("${DOUBLE_BREAK}")
 		}
 
 		//Scope
@@ -112,7 +113,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 			if (traitValue != null)
 			{
 				String traitString = traitValue.toString()
-				if (traitString.startsWith(VisualizerConstants.HTTP) || traitString.startsWith(VisualizerConstants.HTTPS) || traitString.startsWith(VisualizerConstants.FILE))
+				if (traitString.startsWith(HTTP) || traitString.startsWith(HTTPS) || traitString.startsWith(FILE))
 				{
 					sb.append("""<li>${traitName}: <a href="#" onclick='window.open("${traitString}");return false;'>${traitString}</a></li>""")
 				}
@@ -129,7 +130,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		sb.append("<b>Class traits</b>")
 		addTraits(sb, CLASS_TRAITS)
-		sb.append("${VisualizerConstants.BREAK}")
+		sb.append("${BREAK}")
 	}
 
 	@Override
@@ -137,7 +138,7 @@ class RpmVisualizerRelInfo extends VisualizerRelInfo
 	{
 		Iterable<String> splits = Splitter.on('.').split(cubeName)
 		String group = splits[2].toUpperCase()
-		return visInfo.allGroupsKeys.contains(group) ? group : VisualizerConstants.UNSPECIFIED
+		return visInfo.allGroupsKeys.contains(group) ? group : UNSPECIFIED
 	}
 
 	@Override

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerConstants.groovy
@@ -36,6 +36,7 @@ class VisualizerConstants
 	public static final String JSON_FILE_PREFIX = 'config/'
 	public static final String JSON_FILE_SUFFIX = '.json'
 	public static final String VISUALIZER_CONFIG_CUBE_NAME = 'VisualizerConfig'
+	public static final String VISUALIZER_CONFIG_NETWORK_OVERRIDES_CUBE_NAME = 'VisualizerConfig.NetworkOverrides'
 	public static final String CONFIG_ITEM = 'configItem'
 	public static final String CONFIG_NETWORK_OVERRIDES_BASIC = 'networkOverridesBasic'
 	public static final String CONFIG_NETWORK_OVERRIDES_FULL = 'networkOverridesFull'

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerInfo.groovy
@@ -87,13 +87,16 @@ class VisualizerInfo
 
     NCube loadConfigurations(String cubeType)
     {
-        String json = NCubeManager.getResourceAsString(JSON_FILE_PREFIX + VISUALIZER_CONFIG_CUBE_NAME + JSON_FILE_SUFFIX)
-        NCube configCube = NCube.fromSimpleJson(json)
+        String configJson = NCubeManager.getResourceAsString(JSON_FILE_PREFIX + VISUALIZER_CONFIG_CUBE_NAME + JSON_FILE_SUFFIX)
+        NCube configCube = NCube.fromSimpleJson(configJson)
         configCube.applicationID = appId
+        String networkConfigJson = NCubeManager.getResourceAsString(JSON_FILE_PREFIX + VISUALIZER_CONFIG_NETWORK_OVERRIDES_CUBE_NAME + JSON_FILE_SUFFIX)
+        NCube networkConfigCube = NCube.fromSimpleJson(networkConfigJson)
+        networkConfigCube.applicationID = appId
 
-        networkOverridesBasic = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_BASIC, (CUBE_TYPE): cubeType]) as Map
-        networkOverridesFull = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_FULL, (CUBE_TYPE): cubeType]) as Map
-        networkOverridesTopNode = configCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_TOP_NODE, (CUBE_TYPE): cubeType]) as Map
+        networkOverridesBasic = networkConfigCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_BASIC, (CUBE_TYPE): cubeType]) as Map
+        networkOverridesFull = networkConfigCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_FULL, (CUBE_TYPE): cubeType]) as Map
+        networkOverridesTopNode = networkConfigCube.getCell([(CONFIG_ITEM): CONFIG_NETWORK_OVERRIDES_TOP_NODE, (CUBE_TYPE): cubeType]) as Map
         defaultLevel = configCube.getCell([(CONFIG_ITEM): CONFIG_DEFAULT_LEVEL, (CUBE_TYPE): cubeType]) as long
         allGroups = configCube.getCell([(CONFIG_ITEM): CONFIG_ALL_GROUPS, (CUBE_TYPE): cubeType]) as Map
         allGroupsKeys = new LinkedHashSet(allGroups.keySet())

--- a/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerRelInfo.groovy
@@ -96,7 +96,6 @@ class VisualizerRelInfo
 				String cellString = cell == null ? 'null' : cell.toString()
 				targetCellValues[currentCoordinate] = [(cellString): noExecuteCell]
 			}
-			targetCellValues.sort()
 			cellValuesLoadedOk = true
 		}
 	}
@@ -295,12 +294,12 @@ class VisualizerRelInfo
 
 	String getNextTargetCubeName(String targetFieldName)
 	{
-		return null  //TODO
+		return null
 	}
 
 	String getSourceMessage()
 	{
-		return ''  //TODO
+		return ''
 	}
 
 /**

--- a/src/main/resources/config/VisualizerConfig.NetworkOverrides.json
+++ b/src/main/resources/config/VisualizerConfig.NetworkOverrides.json
@@ -1,0 +1,114 @@
+{
+  "ncube": "VisualizerConfig.NetworkOverrides",
+  "default_view_axis_order": "[\"configitem\",\"cubetype\"]",
+  "axes": [
+    {
+      "id": 2,
+      "name": "cubeType",
+      "hasDefault": true,
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 2001950513622,
+          "type": "string",
+          "value": "rpm"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "configItem",
+      "hasDefault": false,
+      "default_value": {
+        "type": "exp",
+        "value": "[:]"
+      },
+      "type": "DISCRETE",
+      "valueType": "STRING",
+      "preferredOrder": 0,
+      "fireAll": true,
+      "columns": [
+        {
+          "id": 1001504517186,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "cache": true,
+            "value": "[:]"
+          },
+          "value": "networkOverridesBasic"
+        },
+        {
+          "id": 1001110976360,
+          "type": "string",
+          "value": "networkOverridesFull"
+        },
+        {
+          "id": 1001036023421,
+          "type": "string",
+          "default_value": {
+            "type": "exp",
+            "value": "[:]"
+          },
+          "value": "networkOverridesTopNode"
+        }
+      ]
+    }
+  ],
+  "cells": [
+    {
+      "id": [
+        1001504517186,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 3,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: true,\n                                        scaleFactor: 0.5\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        PRODUCT: [\n                                shape: 'box',\n                                color: '#DAE4FA'\n                        ],\n                        RISK: [\n                                shape: 'box',\n                                color: '#759BEC'\n                        ],\n                        COVERAGE: [\n                                shape: 'box',\n                                color: '#113275',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        CONTAINER: [\n                                shape: 'star',\n                                color: \"#731d1d\",\n                                font: [\n                                        buttonColor: '#D8D8D8'\n                                ]\n                        ],\n                        LIMIT: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        DEDUCTIBLE: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        PREMIUM: [\n                                shape: 'ellipse',\n                                color: '#0B930B',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        RATE: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        ROLE: [\n                                shape: 'box',\n                                color: '#F59D56'\n                        ],\n                        ROLEPLAYER: [\n                                shape: 'box',\n                                color: '#F2F2F2'\n                        ],\n                        RATEFACTOR: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        PARTY: [\n                                shape: 'box',\n                                color: '#004000',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        PLACE: [\n                                shape: 'box',\n                                color: '#481849',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                        FORM: [\n                                shape: 'box',\n                                color: '#d2691e'\n                        ],\n                        PRODUCT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RISK_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        COVERAGE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        LIMIT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PREMIUM_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATEFACTOR_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLEPLAYER_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        CONTAINER_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        DEDUCTIBLE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PARTY_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PLACE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        UNSPECIFIED_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: '#7ac5cd'\n                        ]\n                ]\n        ]"
+    },
+    {
+      "id": [
+        1001504517186
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 3,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: true,\n                                        scaleFactor: 0.5\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ncube.png',\n\t\t\t\t\t\t\t\tcolor: '#759BEC',\n\t\t\t\t\t\t\t\tshadow: [\n                                                                         color: '#759BEC',\n                                                                         size: 12\n                                ]\n                        ],\n                        RULE_NCUBE: [\n                                 shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ruleNcube.png',\n\t\t\t\t\t\t\t\tcolor: '#EAC259',\n\t\t\t\t\t\t\t\tshadow: [\n                                                                     color: '#EAC259',\n                                                                     size: 12\n                                ]\n                        ],                  \n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                ]\n        ]"
+    },
+    {
+      "id": [
+        1001110976360,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[ nodes:\n\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t  shadow:\n\t\t\t\t\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t\t\t\t\t  enabled: true\n\t\t\t\t\t\t\t\t\t\t  ]\n\t\t\t\t\t\t  ],\n\t\t\t\t  edges:\n\t\t\t\t\t\t  [ arrowStrikethrough:  true,\n\t\t\t\t\t\t\tarrows:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tto:\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\tshadow:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t  ]\n\t\t\t\t]"
+    },
+    {
+      "id": [
+        1001036023421,
+        2001950513622
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                        shapeProperties: [\n                            borderDashes: [5, 2]\n                        ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 40,\n                                max: 40\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40\n                    ];"
+    },
+    {
+      "id": [
+        1001036023421
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[\n                        shapeProperties:\n                            [\n                                useBorderWithImage: true,\n                                borderDashes: [5, 2]\n                            ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 12,\n                                max: 12\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40,\n                        color: '#759BEC'\n                    ]"
+    },
+    {
+      "id": [
+        1001110976360
+      ],
+      "type": "exp",
+      "cache": true,
+      "value": "[ nodes:\n\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t  shadow:\n\t\t\t\t\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t\t\t\t\t  enabled: true\n\t\t\t\t\t\t\t\t\t\t  ]\n\t\t\t\t\t\t  ],\n\t\t\t\t  edges:\n\t\t\t\t\t\t  [ arrowStrikethrough:  true,\n\t\t\t\t\t\t\tarrows:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tto:\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\tshadow:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t  ]\n\t\t\t\t]"
+    }
+  ]
+}

--- a/src/main/resources/config/VisualizerConfig.json
+++ b/src/main/resources/config/VisualizerConfig.json
@@ -53,7 +53,7 @@
           "type": "string",
           "default_value": {
             "type": "long",
-            "value": 3
+            "value": 999999
           },
           "value": "defaultLevel"
         },
@@ -83,13 +83,18 @@
           "default_value": {
             "type": "exp",
             "cache": true,
-            "value": "[:]"
+            "value": "@VisualizerConfig.NetworkOverrides[:]"
           },
           "value": "networkOverridesBasic"
         },
         {
           "id": 1001110976360,
           "type": "string",
+          "default_value": {
+            "type": "exp",
+            "cache": true,
+            "value": "@VisualizerConfig.NetworkOverrides[:]"
+          },
           "value": "networkOverridesFull"
         },
         {
@@ -97,7 +102,8 @@
           "type": "string",
           "default_value": {
             "type": "exp",
-            "value": "[:]"
+            "cache": true,
+            "value": "@VisualizerConfig.NetworkOverrides[:]"
           },
           "value": "networkOverridesTopNode"
         }
@@ -105,15 +111,6 @@
     }
   ],
   "cells": [
-    {
-      "id": [
-        1001504517186,
-        2001950513622
-      ],
-      "type": "exp",
-      "cache": true,
-      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 3,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: false\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        PRODUCT: [\n                                shape: 'box',\n                                color: '#DAE4FA'\n                        ],\n                        RISK: [\n                                shape: 'box',\n                                color: '#759BEC'\n                        ],\n                        COVERAGE: [\n                                shape: 'box',\n                                color: '#113275',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        CONTAINER: [\n                                shape: 'star',\n                                color: \"#731d1d\",\n                                font: [\n                                        buttonColor: '#D8D8D8'\n                                ]\n                        ],\n                        LIMIT: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        DEDUCTIBLE: [\n                                shape: 'ellipse',\n                                color: '#FFFF99'\n                        ],\n                        PREMIUM: [\n                                shape: 'ellipse',\n                                color: '#0B930B',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        RATE: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        ROLE: [\n                                shape: 'box',\n                                color: '#F59D56'\n                        ],\n                        ROLEPLAYER: [\n                                shape: 'box',\n                                color: '#F2F2F2'\n                        ],\n                        RATEFACTOR: [\n                                shape: 'ellipse',\n                                color: '#EAC259'\n                        ],\n                        PARTY: [\n                                shape: 'box',\n                                color: '#004000',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        PLACE: [\n                                shape: 'box',\n                                color: '#481849',\n                                font: [\n                                        color: '#D8D8D8'\n                                ]\n                        ],\n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                        FORM: [\n                                shape: 'box',\n                                color: '#d2691e'\n                        ],\n                        PRODUCT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RISK_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        COVERAGE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        LIMIT_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PREMIUM_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        RATEFACTOR_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLE_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        ROLEPLAYER_ENUM : [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        CONTAINER_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        DEDUCTIBLE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PARTY_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        PLACE_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: 'gray'\n                        ],\n                        UNSPECIFIED_ENUM: [\n                                shape: 'dot',\n                                scaling: [min: 5, max: 5],\n                                color: '#7ac5cd'\n                        ]\n                ]\n        ]"
-    },
     {
       "id": [
         1000052809612,
@@ -163,49 +160,15 @@
       ],
       "type": "exp",
       "cache": true,
-      "value": "['sourceRisk', 'sourceCoverage', 'sourceContainer', 'sourceDeductible', 'sourceLimit', 'sourceRate', 'sourceRatefactor', 'sourcePremium', 'sourceParty', 'sourcePlace', 'sourceRole', 'sourceRoleplayer'] as Set"
+      "value": "//These are not currently used, but may be later so leaving in for now.\n['sourceRisk', 'sourceCoverage', 'sourceContainer', 'sourceDeductible', 'sourceLimit', 'sourceRate', 'sourceRatefactor', 'sourcePremium', 'sourceParty', 'sourcePlace', 'sourceRole', 'sourceRoleplayer'] as Set"
     },
     {
       "id": [
-        1001110976360,
+        1000269251582,
         2001950513622
       ],
-      "type": "exp",
-      "cache": true,
-      "value": "[ nodes:\n\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t  shadow:\n\t\t\t\t\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t\t\t\t\t  enabled: true\n\t\t\t\t\t\t\t\t\t\t  ]\n\t\t\t\t\t\t  ],\n\t\t\t\t  edges:\n\t\t\t\t\t\t  [ arrowStrikethrough:  true,\n\t\t\t\t\t\t\tarrows:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tto:\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\tshadow:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t  ]\n\t\t\t\t]"
-    },
-    {
-      "id": [
-        1001036023421,
-        2001950513622
-      ],
-      "type": "exp",
-      "cache": true,
-      "value": "[\n                        shapeProperties: [\n                            borderDashes: [5, 2]\n                        ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 40,\n                                max: 40\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40\n                    ];"
-    },
-    {
-      "id": [
-        1001036023421
-      ],
-      "type": "exp",
-      "cache": true,
-      "value": "[\n                        shapeProperties:\n                            [\n                                useBorderWithImage: true,\n                                borderDashes: [5, 2]\n                            ],\n                        value: 40,\n                        scaling: [\n                            min: 40,\n                            max: 40,\n                            label: [\n                                enabled: true,\n                                min: 12,\n                                max: 12\n                            ]\n                        ],\n                        borderWidth: 3,\n                        size: 40,\n                        color: '#759BEC'\n                    ]"
-    },
-    {
-      "id": [
-        1001504517186
-      ],
-      "type": "exp",
-      "cache": true,
-      "value": "[\n                interaction: [\n                        navigationButtons: true,\n                        keyboard: [\n                                enabled: false,\n                                speed: [\n                                        x: 5,\n                                        y: 5,\n                                        zoom: 0.02]\n                        ],\n                        zoomView: true\n                ],\n                nodes: [\n\t\t\t\t        borderWidthSelected: 3,\n                        value: 24,\n                        scaling: [\n                                min: 24,\n                                max: 24,\n                                label: [\n                                        enabled: true\n                                ]\n                        ],\n                        shadow: [\n                                enabled: false\n                        ]\n                ],\n                edges: [\n                        arrowStrikethrough: false,\n                        arrows: [\n                                to: [\n                                        enabled: false\n                                ]\n                        ],\n                        color: [\n                                color: 'gray'\n                        ],\n                        smooth: [\n                                enabled: false\n                        ],\n                        shadow: [\n                                enabled: false\n                        ],\n                        hoverWidth: 3,\n                        selectionWidth: 2,\n                        font: [\n                                size: 20\n                        ]\n                ],\n                physics: [\n                        minVelocity: 5,\n                        barnesHut: [\n                                gravitationalConstant: -300000,\n                                springConstant: 0.3,\n                                centralGravity: 3\n                        ]\n                ],\n                layout: [\n                        hierarchical: [\n                                enabled: false\n                        ],\n                        improvedLayout : true,\n                        randomSeed:2\n                ],\n                groups: [\n                        NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ncube.png',\n\t\t\t\t\t\t\t\tcolor: '#759BEC',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#759BEC',\n                                ]\n                        ],\n                        RULE_NCUBE: [\n                                shape: 'image',\n\t\t\t\t\t\t\t\timage: './img/ruleNcube.png',\n\t\t\t\t\t\t\t\tcolor: '#EAC259',\n\t\t\t\t\t\t\t\tshadow: [\n                                        color: '#EAC259',\n                                ]\n                        ],                  \n                        UNSPECIFIED: [\n                                shape: 'box',\n                                color: '#7ac5cd'\n                        ],\n                ]\n        ]"
-    },
-    {
-      "id": [
-        1001110976360
-      ],
-      "type": "exp",
-      "cache": true,
-      "value": "[ nodes:\n\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t  shadow:\n\t\t\t\t\t\t\t\t\t\t  [\n\t\t\t\t\t\t\t\t\t\t\t\t  enabled: true\n\t\t\t\t\t\t\t\t\t\t  ]\n\t\t\t\t\t\t  ],\n\t\t\t\t  edges:\n\t\t\t\t\t\t  [ arrowStrikethrough:  true,\n\t\t\t\t\t\t\tarrows:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tto:\n\t\t\t\t\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t\t\t\t],\n\t\t\t\t\t\t\tshadow:\n\t\t\t\t\t\t\t\t\t[\n\t\t\t\t\t\t\t\t\t\t\tenabled: true ]\n\t\t\t\t\t\t  ]\n\t\t\t\t]"
+      "type": "long",
+      "value": 3
     },
     {
       "id": [
@@ -214,7 +177,7 @@
       ],
       "type": "exp",
       "cache": true,
-      "value": "['action', 'businessDivisionCode', 'context', 'date', 'edition', '_effectiveVersion', 'env', 'formId', 'LocationState', 'screen', 'state', 'transaction', 'transactionsubtype', 'username', 'view'] as Set"
+      "value": "//These are not currently used, but may be later so leaving in for now.\n['action', 'businessDivisionCode', 'context', 'date', 'edition', '_effectiveVersion', 'env', 'formId', 'LocationState', 'screen', 'state', 'transaction', 'transactionsubtype', 'username', 'view'] as Set"
     },
     {
       "id": [

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -113,9 +113,6 @@ h3{
     background-color:rgb(235, 235, 228);
 }
 
-.executeCell, .executeCells{
-    color:#4B0082;
-}
 
 
 


### PR DESCRIPTION

1.	Change link color for cell values to standard blue color.
2.	Change max level for non-rpm cubes to default to 999999. Rpm cubes stay at default of 3 levels.
3.	Reduced size of arrows in graph. I think we had this config at some point, but I deleted it by mistake?
4.	Increased size of node shadows for non-rpm cubes slightly from 10 to 12. This makes them a little bigger, but the color also blurs and makes the shadow less prominent.
5.	Broke out the VisualizerConfig.json into to json to make it easier to edit. Lots of further improvement could be made in cube design here, but not high priority.
6.	Removed obsolete sort of target scope map for non-rpm.
7.	Change RpmVisualizer to return same type as super class where it wasn’t already.
