### PR TITLE
Visualizer: Fix bug in "find node" with multiple hits

### DIFF
--- a/src/main/groovy/com/cedarsoftware/util/VisualizerCellInfo.groovy
+++ b/src/main/groovy/com/cedarsoftware/util/VisualizerCellInfo.groovy
@@ -68,8 +68,9 @@ class VisualizerCellInfo
 		String coordinateClassName = "coord_${id}"
 		String listItemClassName = "${'executedCell'}"
 		String linkClassNames = "${listItemClassName} ${coordinateClassName}"
+		String preClassNames = "${coordinateClassName} wordwrap"
 		sb.append("""<li class="${listItemClassName}" title="Executed cell"><a href="#" class="${linkClassNames}" id="${nodeId}">${coordinateString}</a></li>""")
-		sb.append("""<pre class="${coordinateClassName}">""")
+		sb.append("""<pre class="${preClassNames}">""")
 		sb.append("<b>Non-executed value:</b>")
 		sb.append(DOUBLE_BREAK)
 		sb.append("${noExecuteValue}")
@@ -125,8 +126,9 @@ class VisualizerCellInfo
 
 		String coordinateClassName = "coord_${id}"
 		String linkClassNames = "${listItemClassName}, ${coordinateClassName}"
+		String preClassNames = "${coordinateClassName} wordwrap"
 		sb.append("""<li class="${listItemClassName}" title="${title}"><a href="#" class="${linkClassNames}" id="${nodeId}">${coordinateString}</a></li>""")
-		sb.append("""<pre class="${coordinateClassName}">""")
+		sb.append("""<pre class="${preClassNames}">""")
 		sb.append("<b>Non-executed value:</b>")
 		sb.append(DOUBLE_BREAK)
 		sb.append("${noExecuteValue}")

--- a/src/main/webapp/css/visualize.css
+++ b/src/main/webapp/css/visualize.css
@@ -61,7 +61,7 @@ div.col-width-xs {
     user-select: initial;
 }
 
-pre {
+.wordwrap{
     white-space: pre-wrap;
     white-space: -moz-pre-wrap;
     white-space: -pre-wrap;

--- a/src/main/webapp/js/visualize.js
+++ b/src/main/webapp/js/visualize.js
@@ -214,20 +214,32 @@ var Visualizer = (function ($) {
     }
 
     function onNoteClick(e) {
-        missingScope(e);
+        var target = e.target;
+        if (target.className.indexOf('missingScope') > -1) {
+            missingScope(target);
+        }
+        else if (target.className.indexOf('findNode') > -1) {
+            findNode(target);
+        }
     }
 
-    function missingScope(e) {
-        var target, id, scopeParts, key, value;
-        target = e.target;
-        if (target.className.indexOf('missingScope') > -1) {
-            id = target.title;
-            scopeParts = id.split(':');
-            key = scopeParts[0];
-            value = scopeParts[1].trim();
-            _scope[key] = value;
-            scopeChange();
-        }
+    function missingScope(target) {
+        var id, scopeParts, key, value;
+        id = target.title;
+        scopeParts = id.split(':');
+        key = scopeParts[0];
+        value = scopeParts[1].trim();
+        _scope[key] = value;
+        scopeChange();
+    }
+
+    function findNode(target) {
+        var id, params;
+        id = target.id;
+        params = {nodes: [id]};
+        _network.selectNodes([id]);
+        networkSelectNodeEvent(params);
+        _nce.clearNote();
     }
 
     function addNetworkOptionsListeners() {
@@ -1228,20 +1240,25 @@ var Visualizer = (function ($) {
 
     function addNodeDetailsListeners()
     {
+        var target;
         if (!_nodeDetails.hasClass(HAS_CLICK_EVENT))
         {
             _nodeDetails.click(function (e) {
                 e.preventDefault();
-                missingScope(e);
-                executeCell(e);
+                target = e.target;
+                if (target.className.indexOf('missingScope') > -1) {
+                    missingScope(target);
+                }
+                else{
+                    executeCell(target);
+                }
             });
             _nodeDetails.addClass(HAS_CLICK_EVENT)
         }
     }
 
-    function executeCell(e) {
-        var target, coordinateId;
-        target = e.target;
+    function executeCell(target) {
+        var coordinateId;
         if (target.className.indexOf('expandAll') > -1) {
             $('pre[class^="coord_"]').show();
         }


### PR DESCRIPTION
1. Fix bug in doing find on node with multiple hits. Links in toast were not working.
2. Only apply word wrapping on pre tags in info panel for non-rpm cell values. 