### PR TITLE
Revert "Expression link would not properly open cube contained in tab overflow."

### DIFF
--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -1215,7 +1215,7 @@ var NCE = (function ($) {
                                     removeTab(cubeInfo);
                                 } else {
                                     makeCubeInfoActive(cubeInfo);
-                                    buildTabs(true);
+                                    buildTabs(true, cubeInfo);
                                 }
                             })
                     )
@@ -1475,7 +1475,7 @@ var NCE = (function ($) {
                         selectTab(cubeInfo);
                     } else {
                         makeCubeInfoActive(cubeInfo);
-                        buildTabs(true);
+                        buildTabs();
                         return;
                     }
                     found = true;


### PR DESCRIPTION
Reverts jdereg/n-cube-editor#417